### PR TITLE
fix(parser): 10 conversion-accuracy fixes for JS/TS and Python

### DIFF
--- a/__tests__/parser-js-accuracy.test.ts
+++ b/__tests__/parser-js-accuracy.test.ts
@@ -25,3 +25,27 @@ describe('fix 1: function-valued expressions render their bodies', () => {
     expect(out).toContain('(["const check = (x) =&gt;"])')
   })
 })
+
+describe('fix 2: classes render members', () => {
+  test('class with methods renders subroutine + method bodies', () => {
+    const code = 'class Stack extends Base {\n  constructor() { super(); this.items = [] }\n  pop() {\n    if (this.items.length === 0) return null\n    return this.items.pop()\n  }\n}'
+    const out = codeToMermaid(code, 'javascript')
+    expect(out).toContain('class Stack extends Base')
+    expect(out).toContain('(["constructor()"])')
+    expect(out).toContain('(["pop()"])')
+    expect(out).toContain('this.items.length === 0?')
+    expect(out).not.toContain('ClassDeclaration')
+  })
+
+  test('class field renders as a process node', () => {
+    const out = codeToMermaid('class A {\n  count = 0\n  reset() { this.count = 0 }\n}', 'javascript')
+    expect(out).toContain('["count = 0"]')
+    expect(out).toContain('(["reset()"])')
+  })
+
+  test('class expression assigned to const', () => {
+    const out = codeToMermaid('const A = class {\n  go() { run() }\n}', 'javascript')
+    expect(out).toContain('class A')
+    expect(out).toContain('(["go()"])')
+  })
+})

--- a/__tests__/parser-js-accuracy.test.ts
+++ b/__tests__/parser-js-accuracy.test.ts
@@ -1,0 +1,27 @@
+import { codeToMermaid } from '@/lib/parser'
+
+describe('fix 1: function-valued expressions render their bodies', () => {
+  test('arrow function assigned to const', () => {
+    const out = codeToMermaid('const add = (a, b) => {\n  if (a > b) return a\n  return b\n}', 'javascript')
+    expect(out).toContain('(["const add = (a, b) =&gt;"])')
+    expect(out).toContain('a &gt; b?')
+    expect(out).toContain('(["end add"])')
+  })
+
+  test('function expression assigned to a property', () => {
+    const out = codeToMermaid('obj.handler = function (e) {\n  if (e) log(e)\n}', 'javascript')
+    expect(out).toContain('(["obj.handler = function(e)"])')
+    expect(out).toContain('{"e?"}')
+  })
+
+  test('expression-bodied arrow stays a single process node', () => {
+    const out = codeToMermaid('const double = x => x * 2', 'javascript')
+    expect(out).not.toContain('end double')
+  })
+
+  test('mixed declaration keeps plain declarators and expands the function one', () => {
+    const out = codeToMermaid('const limit = 5, check = (x) => {\n  return x < limit\n}', 'javascript')
+    expect(out).toContain('["const limit = 5"]')
+    expect(out).toContain('(["const check = (x) =&gt;"])')
+  })
+})

--- a/__tests__/parser-js-accuracy.test.ts
+++ b/__tests__/parser-js-accuracy.test.ts
@@ -61,3 +61,27 @@ describe('fix 3: switch no-match edge', () => {
     expect(out).not.toContain('no match')
   })
 })
+
+describe('fix 4: labeled statements', () => {
+  test('labeled loop renders and break outer exits the outer loop', () => {
+    const code = 'outer: for (const a of xs) {\n  for (const b of ys) {\n    if (a === b) break outer\n  }\n}\ndone()'
+    const out = codeToMermaid(code, 'javascript')
+    expect(out).not.toContain('"Labeled"')
+    expect(out).toContain('a of xs?')
+    const breakId = out.match(/(N\d+)\["break outer"\]/)?.[1]
+    const doneId  = out.match(/(N\d+)\["done\(\)"\]/)?.[1]
+    expect(breakId).toBeTruthy()
+    expect(doneId).toBeTruthy()
+    // the node break jumps to must be the outer loop's merge — the one that leads to done()
+    const outerMerge = out.match(new RegExp(`(N\\d+) --> ${doneId}\\b`))?.[1]
+    expect(out).toContain(`${breakId} --> ${outerMerge}`)
+  })
+
+  test('labeled continue targets the labeled loop condition', () => {
+    const code = 'outer: while (a) {\n  while (b) {\n    continue outer\n  }\n}'
+    const out = codeToMermaid(code, 'javascript')
+    const contId = out.match(/(N\d+)\["continue outer"\]/)?.[1]
+    const outerCond = out.match(/(N\d+)\{"a\?"\}/)?.[1]
+    expect(out).toContain(`${contId} --> ${outerCond}`)
+  })
+})

--- a/__tests__/parser-js-accuracy.test.ts
+++ b/__tests__/parser-js-accuracy.test.ts
@@ -97,3 +97,21 @@ describe('fix 4: labeled statements', () => {
     expect(out).toContain(`${contId} --> ${cond}`)
   })
 })
+
+describe('fix 5: throw routes to catch', () => {
+  test('throw inside try connects to the catch node', () => {
+    const code = "try {\n  if (bad) throw new Error('x')\n  ok()\n} catch (e) {\n  handle(e)\n}"
+    const out = codeToMermaid(code, 'javascript')
+    const throwId = out.match(/(N\d+)\["throw new Error\('x'\)"\]/)?.[1]
+    const catchId = out.match(/(N\d+)\(\["catch \(e\)"\]\)/)?.[1]
+    expect(throwId).toBeTruthy()
+    expect(catchId).toBeTruthy()
+    expect(out).toContain(`${throwId} --> ${catchId}`)
+  })
+
+  test('throw with no enclosing try stays terminal', () => {
+    const out = codeToMermaid("throw new Error('boom')", 'javascript')
+    const throwId = out.match(/(N\d+)\["throw new Error\('boom'\)"\]/)?.[1]
+    expect(out).not.toMatch(new RegExp(`${throwId} --> `))
+  })
+})

--- a/__tests__/parser-js-accuracy.test.ts
+++ b/__tests__/parser-js-accuracy.test.ts
@@ -84,4 +84,16 @@ describe('fix 4: labeled statements', () => {
     const outerCond = out.match(/(N\d+)\{"a\?"\}/)?.[1]
     expect(out).toContain(`${contId} --> ${outerCond}`)
   })
+
+  test('doubly-labeled loop resolves both labels', () => {
+    const code = 'outer: inner: for (const a of xs) {\n  if (bad(a)) break outer\n  if (odd(a)) continue inner\n}\ndone()'
+    const out = codeToMermaid(code, 'javascript')
+    const breakId = out.match(/(N\d+)\["break outer"\]/)?.[1]
+    const doneId  = out.match(/(N\d+)\["done\(\)"\]/)?.[1]
+    const merge   = out.match(new RegExp(`(N\\d+) --> ${doneId}\\b`))?.[1]
+    expect(out).toContain(`${breakId} --> ${merge}`)
+    const contId  = out.match(/(N\d+)\["continue inner"\]/)?.[1]
+    const cond    = out.match(/(N\d+)\{"const a of xs\?"\}/)?.[1]
+    expect(out).toContain(`${contId} --> ${cond}`)
+  })
 })

--- a/__tests__/parser-js-accuracy.test.ts
+++ b/__tests__/parser-js-accuracy.test.ts
@@ -49,3 +49,15 @@ describe('fix 2: classes render members', () => {
     expect(out).toContain('(["go()"])')
   })
 })
+
+describe('fix 3: switch no-match edge', () => {
+  test('switch without default connects decision to merge', () => {
+    const out = codeToMermaid('switch (x) {\n  case 1:\n    a()\n    break\n}\ndone()', 'javascript')
+    expect(out).toContain('-->|no match|')
+  })
+
+  test('switch with default gets no extra edge', () => {
+    const out = codeToMermaid('switch (x) {\n  case 1:\n    a()\n    break\n  default:\n    d()\n}', 'javascript')
+    expect(out).not.toContain('no match')
+  })
+})

--- a/__tests__/parser-python-accuracy.test.ts
+++ b/__tests__/parser-python-accuracy.test.ts
@@ -28,3 +28,44 @@ describe('fix 6: single-line suites', () => {
     expect(out).toContain('print(x)')
   })
 })
+
+describe('fix 8 (parse): else attaches to the nearest preceding block', () => {
+  test('else after try does not steal from an earlier if', () => {
+    const code = 'if a:\n    one()\ntry:\n    risky()\nexcept:\n    handle()\nelse:\n    ok()'
+    const out = codeToMermaid(code, 'python')
+    const aCond = out.match(/(N\d+)\{"a\?"\}/)?.[1]
+    const okId  = out.match(/(N\d+)\["ok\(\)"\]/)?.[1]
+    expect(okId).toBeTruthy()
+    // the if's No edge must not lead to ok()
+    expect(out).not.toContain(`${aCond} -->|No| ${okId}`)
+  })
+})
+
+describe('fix 8 (render): try/except/else', () => {
+  test('else block runs after try body succeeds', () => {
+    const code = 'try:\n    risky()\nexcept ValueError:\n    handle()\nelse:\n    celebrate()\nprint("done")'
+    const out = codeToMermaid(code, 'python')
+    const riskyId = out.match(/(N\d+)\["risky\(\)"\]/)?.[1]
+    const celebId = out.match(/(N\d+)\["celebrate\(\)"\]/)?.[1]
+    expect(celebId).toBeTruthy()
+    expect(out).toContain(`${riskyId} --> ${celebId}`)
+  })
+})
+
+describe('fix 5 (python): raise routes to except', () => {
+  test('raise inside try connects to the first except node', () => {
+    const code = 'try:\n    if bad:\n        raise ValueError("x")\n    ok()\nexcept ValueError:\n    handle()'
+    const out = codeToMermaid(code, 'python')
+    const raiseId = out.match(/(N\d+)\["raise ValueError\('x'\)"\]/)?.[1]
+    const exceptId = out.match(/(N\d+)\(\["except ValueError"\]\)/)?.[1]
+    expect(raiseId).toBeTruthy()
+    expect(exceptId).toBeTruthy()
+    expect(out).toContain(`${raiseId} --> ${exceptId}`)
+  })
+
+  test('raise with no enclosing try stays terminal', () => {
+    const out = codeToMermaid('raise RuntimeError("boom")', 'python')
+    const raiseId = out.match(/(N\d+)\["raise RuntimeError\('boom'\)"\]/)?.[1]
+    expect(out).not.toMatch(new RegExp(`${raiseId} --> `))
+  })
+})

--- a/__tests__/parser-python-accuracy.test.ts
+++ b/__tests__/parser-python-accuracy.test.ts
@@ -80,3 +80,31 @@ describe('fix 9: while-else', () => {
     expect(out).toContain(`${condId} -->|No| ${cleanId}`)
   })
 })
+
+describe('fix 10: async constructs', () => {
+  test('async def renders its body with async label', () => {
+    const code = 'async def fetch(url):\n    if not url:\n        return None\n    return await get(url)'
+    const out = codeToMermaid(code, 'python')
+    expect(out).toContain('async def fetch(url)')
+    expect(out).toContain('not url?')
+    // body must nest inside the def: return routes to the function end node
+    const retId = out.match(/(N\d+)\["return None"\]/)?.[1]
+    const endId = out.match(/(N\d+)\(\["end fetch"\]\)/)?.[1]
+    expect(out).toContain(`${retId} --> ${endId}`)
+  })
+
+  test('async with and async for parse as blocks', () => {
+    const code = 'async def main():\n    async with session() as s:\n        async for item in s.stream():\n            handle(item)'
+    const out = codeToMermaid(code, 'python')
+    expect(out).toContain('async with session() as s')
+    expect(out).toContain('item in s.stream()?')
+    expect(out).toContain('handle(item)')
+  })
+
+  test('def with return annotation parses', () => {
+    const code = 'def size(x) -> int:\n    return len(x)'
+    const out = codeToMermaid(code, 'python')
+    expect(out).toContain('def size(x)')
+    expect(out).toContain('return len(x)')
+  })
+})

--- a/__tests__/parser-python-accuracy.test.ts
+++ b/__tests__/parser-python-accuracy.test.ts
@@ -1,0 +1,9 @@
+import { codeToMermaid } from '@/lib/parser'
+
+describe('fix 7: multi-line statements', () => {
+  test('call split across lines renders as one node', () => {
+    const out = codeToMermaid('result = compute(\n    alpha,\n    beta,\n)\nprint(result)', 'python')
+    expect(out).toContain('result = compute( alpha, beta, )')
+    expect(out).not.toContain('["alpha,"]')
+  })
+})

--- a/__tests__/parser-python-accuracy.test.ts
+++ b/__tests__/parser-python-accuracy.test.ts
@@ -7,3 +7,24 @@ describe('fix 7: multi-line statements', () => {
     expect(out).not.toContain('["alpha,"]')
   })
 })
+
+describe('fix 6: single-line suites', () => {
+  test('inline if body is kept', () => {
+    const out = codeToMermaid('x = 1\nif x > 0: print("positive")\nprint("done")', 'python')
+    expect(out).toContain('x &gt; 0?')
+    expect(out).toContain("print('positive')")
+    expect(out).toContain('-->|Yes|')
+  })
+
+  test('semicolon-separated inline suite renders every statement', () => {
+    const out = codeToMermaid('if flag: a(); b()', 'python')
+    expect(out).toContain('["a()"]')
+    expect(out).toContain('["b()"]')
+  })
+
+  test('colon inside a slice or string does not split the header', () => {
+    const out = codeToMermaid('for x in d[1:5]:\n    print(x)', 'python')
+    expect(out).toContain('x in d[1:5]?')
+    expect(out).toContain('print(x)')
+  })
+})

--- a/__tests__/parser-python-accuracy.test.ts
+++ b/__tests__/parser-python-accuracy.test.ts
@@ -69,3 +69,14 @@ describe('fix 5 (python): raise routes to except', () => {
     expect(out).not.toMatch(new RegExp(`${raiseId} --> `))
   })
 })
+
+describe('fix 9: while-else', () => {
+  test('else body renders on the No path', () => {
+    const code = 'while cond():\n    work()\nelse:\n    cleanup()\nprint("done")'
+    const out = codeToMermaid(code, 'python')
+    const condId = out.match(/(N\d+)\{"cond\(\)\?"\}/)?.[1]
+    const cleanId = out.match(/(N\d+)\["cleanup\(\)"\]/)?.[1]
+    expect(cleanId).toBeTruthy()
+    expect(out).toContain(`${condId} -->|No| ${cleanId}`)
+  })
+})

--- a/__tests__/python-lines.test.ts
+++ b/__tests__/python-lines.test.ts
@@ -1,0 +1,47 @@
+import { toLogicalLines, topLevelIndexOf, splitTopLevel } from '@/lib/parser/python-lines'
+
+describe('toLogicalLines', () => {
+  test('joins bracket continuations into one logical line', () => {
+    const out = toLogicalLines('result = compute(\n    alpha,\n    beta,\n)\nprint(result)')
+    expect(out.map(l => l.text)).toEqual(['result = compute( alpha, beta, )', 'print(result)'])
+    expect(out[0].indent).toBe(0)
+    expect(out[0].lineNum).toBe(1)
+  })
+
+  test('joins backslash continuations', () => {
+    const out = toLogicalLines('total = a + \\\n    b')
+    expect(out.map(l => l.text)).toEqual(['total = a + b'])
+  })
+
+  test('strips comments outside strings only', () => {
+    const out = toLogicalLines('x = "a # b"  # real comment\n# full-line comment\ny = 1')
+    expect(out.map(l => l.text)).toEqual(['x = "a # b"', 'y = 1'])
+  })
+
+  test('brackets inside strings do not open continuations', () => {
+    const out = toLogicalLines('msg = "if you see this: fine ("\nprint(msg)')
+    expect(out).toHaveLength(2)
+  })
+
+  test('triple-quoted string spanning lines stays one logical line', () => {
+    const out = toLogicalLines('doc = """line one\nline two"""\nprint(doc)')
+    expect(out).toHaveLength(2)
+    expect(out[0].text).toContain('line two')
+  })
+
+  test('unclosed bracket at EOF still flushes', () => {
+    const out = toLogicalLines('x = f(\n    1,')
+    expect(out).toHaveLength(1)
+  })
+})
+
+describe('topLevelIndexOf / splitTopLevel', () => {
+  test('skips colons inside brackets and strings', () => {
+    expect(topLevelIndexOf('if d[1:2] and "a:b": pass', ':')).toBe(19)
+    expect(topLevelIndexOf('x = 1', ':')).toBe(-1)
+  })
+
+  test('splits on top-level separators only', () => {
+    expect(splitTopLevel('a(); b("x;y"); c()', ';')).toEqual(['a()', ' b("x;y")', ' c()'])
+  })
+})

--- a/docs/superpowers/plans/2026-07-10-parser-accuracy-part1-js.md
+++ b/docs/superpowers/plans/2026-07-10-parser-accuracy-part1-js.md
@@ -1,0 +1,549 @@
+# Parser Accuracy Part 1 (JavaScript/TypeScript) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix the 5 confirmed JS/TS conversion-accuracy defects (spec: `docs/superpowers/specs/2026-07-10-parser-accuracy-design.md` fixes 1–5).
+
+**Architecture:** All changes stay inside the existing pipeline: acorn AST → recursive `process*` handlers building a `FlowchartGraph` → Mermaid. We extract a shared `processFunctionBody` helper, add class/labeled-statement handlers, and extend `TraversalContext` with labeled-break targets and a throw target.
+
+**Tech Stack:** TypeScript, acorn, jest (`npx jest`). Tests import via the `@/lib/parser` alias.
+
+## Global Constraints
+
+- No new dependencies.
+- Only touch: `lib/parser/javascript.ts`, `lib/parser/types.ts`, new test file `__tests__/parser-js-accuracy.test.ts`.
+- Existing tests in `__tests__/parser.test.ts` must keep passing (`npx jest`).
+- Mermaid labels are escaped by `converter.ts` (`>` → `&gt;`, `"` → `'`) — test expectations must use the escaped form.
+- Commit messages: conventional style, **no Co-Authored-By trailer**.
+
+---
+
+### Task 1: `processFunctionBody` helper + arrow/function-expression bodies (fix 1)
+
+**Files:**
+- Modify: `lib/parser/javascript.ts` (`processFunction` ~line 90, `processVariable` ~line 280, `processExpression` ~line 289)
+- Test: `__tests__/parser-js-accuracy.test.ts` (create)
+
+**Interfaces:**
+- Consumes: existing `processBlock`, `formatExpression`, `TraversalContext`.
+- Produces: `function processFunctionBody(label: string, endLabel: string, bodyStatements: any[], ctx: TraversalContext): BlockResult` and `function isBlockFunction(n: any): boolean` — Task 2 calls both.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `__tests__/parser-js-accuracy.test.ts`:
+
+```ts
+import { codeToMermaid } from '@/lib/parser'
+
+describe('fix 1: function-valued expressions render their bodies', () => {
+  test('arrow function assigned to const', () => {
+    const out = codeToMermaid('const add = (a, b) => {\n  if (a > b) return a\n  return b\n}', 'javascript')
+    expect(out).toContain('(["const add = (a, b) =&gt;"])')
+    expect(out).toContain('a &gt; b?')
+    expect(out).toContain('(["end add"])')
+  })
+
+  test('function expression assigned to a property', () => {
+    const out = codeToMermaid('obj.handler = function (e) {\n  if (e) log(e)\n}', 'javascript')
+    expect(out).toContain('(["obj.handler = function(e)"])')
+    expect(out).toContain('{"e?"}')
+  })
+
+  test('expression-bodied arrow stays a single process node', () => {
+    const out = codeToMermaid('const double = x => x * 2', 'javascript')
+    expect(out).not.toContain('end double')
+  })
+
+  test('mixed declaration keeps plain declarators and expands the function one', () => {
+    const out = codeToMermaid('const limit = 5, check = (x) => {\n  return x < limit\n}', 'javascript')
+    expect(out).toContain('["const limit = 5"]')
+    expect(out).toContain('(["const check = (x) =&gt;"])')
+  })
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx jest __tests__/parser-js-accuracy.test.ts`
+Expected: 4 failures — output currently contains one opaque `const add = () =&gt; {...}` box, no `end add`.
+
+- [ ] **Step 3: Implement**
+
+In `lib/parser/javascript.ts`, replace `processFunction` with the helper + thin wrapper:
+
+```ts
+function processFunctionBody(label: string, endLabel: string, bodyStatements: any[], ctx: TraversalContext): BlockResult {
+  const funcNode = ctx.graph.createNode('subroutine', label, 'rounded')
+  const endNode  = ctx.graph.createNode('process', endLabel, 'rounded')
+  const fCtx = ctx.clone()
+  fCtx.currentNode = funcNode
+  fCtx.returnTarget = endNode
+  // function boundary: enclosing loop targets don't apply inside the body
+  fCtx.breakTarget = null
+  fCtx.continueTarget = null
+  const body = processBlock(bodyStatements, fCtx)
+  if (body.entry) ctx.graph.connect(funcNode, body.entry)
+  if (body.exit)  ctx.graph.connect(body.exit, endNode)
+  return { entry: funcNode, exit: endNode }
+}
+
+function isBlockFunction(n: any): boolean {
+  return !!n && (n.type === 'ArrowFunctionExpression' || n.type === 'FunctionExpression') && n.body?.type === 'BlockStatement'
+}
+
+function functionLabel(prefix: string, fn: any): string {
+  const params = fn.params.map((p: any) => formatExpression(p)).join(', ')
+  return fn.type === 'ArrowFunctionExpression' ? `${prefix} = (${params}) =>` : `${prefix} = function(${params})`
+}
+
+function processFunction(node: any, ctx: TraversalContext): BlockResult {
+  const name = node.id?.name ?? 'anonymous'
+  const params = node.params.map((p: any) => formatExpression(p)).join(', ')
+  return processFunctionBody(`function ${name}(${params})`, `end ${name}`, node.body.body, ctx)
+}
+```
+
+Replace `processVariable`:
+
+```ts
+function processVariable(node: any, ctx: TraversalContext): BlockResult {
+  if (!node.declarations.some((d: any) => isBlockFunction(d.init))) {
+    const decls = node.declarations.map((d: any) => {
+      const name = formatExpression(d.id)
+      return d.init ? `${name} = ${formatExpression(d.init)}` : name
+    }).join(', ')
+    const n = ctx.graph.createNode('process', `${node.kind} ${decls}`, 'rectangle')
+    return { entry: n, exit: n }
+  }
+  // At least one declarator holds a function with a block body: render each
+  // declarator separately so the function's control flow stays visible.
+  let first: FlowchartNode | null = null
+  let prev: FlowchartNode | null = null
+  for (const d of node.declarations) {
+    const name = formatExpression(d.id)
+    let r: BlockResult
+    if (isBlockFunction(d.init)) {
+      r = processFunctionBody(functionLabel(`${node.kind} ${name}`, d.init), `end ${name}`, d.init.body.body, ctx)
+    } else {
+      const label = d.init ? `${node.kind} ${name} = ${formatExpression(d.init)}` : `${node.kind} ${name}`
+      const n = ctx.graph.createNode('process', label, 'rectangle')
+      r = { entry: n, exit: n }
+    }
+    if (!first) first = r.entry
+    if (prev && r.entry) ctx.graph.connect(prev, r.entry)
+    prev = r.exit
+  }
+  return { entry: first, exit: prev }
+}
+```
+
+Replace `processExpression`:
+
+```ts
+function processExpression(node: any, ctx: TraversalContext): BlockResult {
+  const expr = node.expression
+  if (expr.type === 'AssignmentExpression' && expr.operator === '=' && isBlockFunction(expr.right)) {
+    const target = formatExpression(expr.left)
+    return processFunctionBody(functionLabel(target, expr.right), `end ${target}`, expr.right.body.body, ctx)
+  }
+  const n = ctx.graph.createNode('process', formatExpression(expr), 'rectangle')
+  return { entry: n, exit: n }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx jest __tests__/parser-js-accuracy.test.ts __tests__/parser.test.ts`
+Expected: all PASS (existing suite included).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/parser/javascript.ts __tests__/parser-js-accuracy.test.ts
+git commit -m "fix(parser): render arrow/function-expression bodies as subroutines"
+```
+
+---
+
+### Task 2: Class declarations render members (fix 2)
+
+**Files:**
+- Modify: `lib/parser/javascript.ts` (`processStatement` switch ~line 54, `formatExpression` ~line 11, `parseJS` ~line 39)
+- Test: `__tests__/parser-js-accuracy.test.ts`
+
+**Interfaces:**
+- Consumes: `processFunctionBody`, `isBlockFunction`, `functionLabel` from Task 1.
+- Produces: `function processClassJS(node: any, ctx: TraversalContext): BlockResult`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `__tests__/parser-js-accuracy.test.ts`:
+
+```ts
+describe('fix 2: classes render members', () => {
+  test('class with methods renders subroutine + method bodies', () => {
+    const code = 'class Stack extends Base {\n  constructor() { super(); this.items = [] }\n  pop() {\n    if (this.items.length === 0) return null\n    return this.items.pop()\n  }\n}'
+    const out = codeToMermaid(code, 'javascript')
+    expect(out).toContain('class Stack extends Base')
+    expect(out).toContain('(["constructor()"])')
+    expect(out).toContain('(["pop()"])')
+    expect(out).toContain('this.items.length === 0?')
+    expect(out).not.toContain('ClassDeclaration')
+  })
+
+  test('class field renders as a process node', () => {
+    const out = codeToMermaid('class A {\n  count = 0\n  reset() { this.count = 0 }\n}', 'javascript')
+    expect(out).toContain('["count = 0"]')
+    expect(out).toContain('(["reset()"])')
+  })
+
+  test('class expression assigned to const', () => {
+    const out = codeToMermaid('const A = class {\n  go() { run() }\n}', 'javascript')
+    expect(out).toContain('class A')
+    expect(out).toContain('(["go()"])')
+  })
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx jest __tests__/parser-js-accuracy.test.ts -t "fix 2"`
+Expected: FAIL — first test shows `ClassDeclaration` box; second may fail at parse (class fields need ecmaVersion > 2020).
+
+- [ ] **Step 3: Implement**
+
+In `parseJS`, change `ecmaVersion: 2020` → `ecmaVersion: 'latest'` (class fields are ES2022).
+
+In `formatExpression`, add a case (anywhere in the switch): `case 'Super': text = 'super'; break`.
+
+Add handler + switch cases:
+
+```ts
+function processClassJS(node: any, ctx: TraversalContext): BlockResult {
+  const name = node.id?.name ?? 'anonymous'
+  const base = node.superClass ? ` extends ${formatExpression(node.superClass)}` : ''
+  const cls  = ctx.graph.createNode('subroutine', `class ${name}${base}`, 'rounded')
+  let prev: FlowchartNode = cls
+  for (const m of node.body.body) {
+    let r: BlockResult | null = null
+    if (m.type === 'MethodDefinition' && m.value?.body) {
+      const key = formatExpression(m.key)
+      const params = m.value.params.map((p: any) => formatExpression(p)).join(', ')
+      let label = `${key}(${params})`
+      if (m.kind === 'get') label = `get ${label}`
+      if (m.kind === 'set') label = `set ${label}`
+      if (m.static) label = `static ${label}`
+      r = processFunctionBody(label, `end ${key}`, m.value.body.body, ctx)
+    } else if (m.type === 'PropertyDefinition') {
+      const key = formatExpression(m.key)
+      if (isBlockFunction(m.value)) {
+        r = processFunctionBody(functionLabel(key, m.value), `end ${key}`, m.value.body.body, ctx)
+      } else {
+        const n = ctx.graph.createNode('process', m.value ? `${key} = ${formatExpression(m.value)}` : key, 'rectangle')
+        r = { entry: n, exit: n }
+      }
+    }
+    if (r?.entry) { ctx.graph.connect(prev, r.entry); prev = r.exit ?? prev }
+  }
+  return { entry: cls, exit: prev }
+}
+```
+
+In `processStatement`, add before `default`: `case 'ClassDeclaration': return processClassJS(node, ctx)`.
+
+In Task 1's `processVariable` function-path loop, extend the special case: change the `some(...)` guard to `node.declarations.some((d: any) => isBlockFunction(d.init) || d.init?.type === 'ClassExpression')` and inside the loop add before the `isBlockFunction` branch:
+
+```ts
+if (d.init?.type === 'ClassExpression') {
+  r = processClassJS({ ...d.init, id: d.init.id ?? d.id }, ctx)
+} else if (isBlockFunction(d.init)) { ...existing... }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx jest __tests__/parser-js-accuracy.test.ts __tests__/parser.test.ts`
+Expected: all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/parser/javascript.ts __tests__/parser-js-accuracy.test.ts
+git commit -m "fix(parser): render class members instead of opaque ClassDeclaration box"
+```
+
+---
+
+### Task 3: Switch without default gets a no-match edge (fix 3)
+
+**Files:**
+- Modify: `lib/parser/javascript.ts` (`processSwitch` ~line 200)
+- Test: `__tests__/parser-js-accuracy.test.ts`
+
+**Interfaces:** none new.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+describe('fix 3: switch no-match edge', () => {
+  test('switch without default connects decision to merge', () => {
+    const out = codeToMermaid('switch (x) {\n  case 1:\n    a()\n    break\n}\ndone()', 'javascript')
+    expect(out).toContain('-->|no match|')
+  })
+
+  test('switch with default gets no extra edge', () => {
+    const out = codeToMermaid('switch (x) {\n  case 1:\n    a()\n    break\n  default:\n    d()\n}', 'javascript')
+    expect(out).not.toContain('no match')
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx jest __tests__/parser-js-accuracy.test.ts -t "fix 3"`
+Expected: first test FAILs (no `no match` edge exists today).
+
+- [ ] **Step 3: Implement**
+
+In `processSwitch`, before `return { entry: sw, exit: after }`:
+
+```ts
+if (!node.cases.some((c: any) => !c.test)) ctx.graph.connect(sw, after, 'no match')
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx jest __tests__/parser-js-accuracy.test.ts __tests__/parser.test.ts`
+Expected: all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/parser/javascript.ts __tests__/parser-js-accuracy.test.ts
+git commit -m "fix(parser): add no-match exit edge for switch without default"
+```
+
+---
+
+### Task 4: Labeled statements + labeled break/continue (fix 4)
+
+**Files:**
+- Modify: `lib/parser/types.ts` (`TraversalContext` ~line 56)
+- Modify: `lib/parser/javascript.ts` (`processStatement`, `processFor`, `processWhile`, `processDoWhile`, `processForIn`, `processSwitch`, `processBreak`, `processContinue`)
+- Test: `__tests__/parser-js-accuracy.test.ts`
+
+**Interfaces:**
+- Produces on `TraversalContext`: `labeledTargets: Record<string, { break: FlowchartNode | null; continue: FlowchartNode | null }>` and `pendingLabel: string | null` (both copied by `clone()`).
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+describe('fix 4: labeled statements', () => {
+  test('labeled loop renders and break outer exits the outer loop', () => {
+    const code = 'outer: for (const a of xs) {\n  for (const b of ys) {\n    if (a === b) break outer\n  }\n}\ndone()'
+    const out = codeToMermaid(code, 'javascript')
+    expect(out).not.toContain('"Labeled"')
+    expect(out).toContain('a of xs?')
+    const breakId = out.match(/(N\d+)\["break outer"\]/)?.[1]
+    const doneId  = out.match(/(N\d+)\["done\(\)"\]/)?.[1]
+    expect(breakId).toBeTruthy()
+    expect(doneId).toBeTruthy()
+    // the node break jumps to must be the outer loop's merge — the one that leads to done()
+    const outerMerge = out.match(new RegExp(`(N\\d+) --> ${doneId}\\b`))?.[1]
+    expect(out).toContain(`${breakId} --> ${outerMerge}`)
+  })
+
+  test('labeled continue targets the labeled loop condition', () => {
+    const code = 'outer: while (a) {\n  while (b) {\n    continue outer\n  }\n}'
+    const out = codeToMermaid(code, 'javascript')
+    const contId = out.match(/(N\d+)\["continue outer"\]/)?.[1]
+    const outerCond = out.match(/(N\d+)\{"a\?"\}/)?.[1]
+    expect(out).toContain(`${contId} --> ${outerCond}`)
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx jest __tests__/parser-js-accuracy.test.ts -t "fix 4"`
+Expected: FAIL — output contains a single node labeled `Labeled`.
+
+- [ ] **Step 3: Implement**
+
+`lib/parser/types.ts` — add to `TraversalContext`:
+
+```ts
+labeledTargets: Record<string, { break: FlowchartNode | null; continue: FlowchartNode | null }> = {}
+pendingLabel: string | null = null
+```
+
+and in `clone()` add:
+
+```ts
+ctx.labeledTargets = { ...this.labeledTargets }
+ctx.pendingLabel = this.pendingLabel
+```
+
+`lib/parser/javascript.ts` — in `processStatement`, add before `default`:
+
+```ts
+case 'LabeledStatement': {
+  const lCtx = ctx.clone()
+  lCtx.pendingLabel = node.label.name
+  return processStatement(node.body, lCtx)
+}
+```
+
+Add this registration line to each loop handler, immediately **before** the body context is cloned (the `ctx.clone()` call for `loopCtx`/`lCtx`), so the body context inherits the entry. The `continue` value differs per handler:
+
+- `processFor` (before `const loopCtx = ctx.clone()`):
+  `if (ctx.pendingLabel) { ctx.labeledTargets[ctx.pendingLabel] = { break: after, continue: update ?? cond }; ctx.pendingLabel = null }`
+- `processWhile` (before `const lCtx = ctx.clone()`):
+  `if (ctx.pendingLabel) { ctx.labeledTargets[ctx.pendingLabel] = { break: after, continue: cond }; ctx.pendingLabel = null }`
+- `processDoWhile` (before `const lCtx = ctx.clone()`):
+  `if (ctx.pendingLabel) { ctx.labeledTargets[ctx.pendingLabel] = { break: after, continue: cond }; ctx.pendingLabel = null }`
+- `processForIn` (before `const lCtx = ctx.clone()`):
+  `if (ctx.pendingLabel) { ctx.labeledTargets[ctx.pendingLabel] = { break: after, continue: cond }; ctx.pendingLabel = null }`
+- `processSwitch` (before the `for (const c of node.cases)` loop):
+  `if (ctx.pendingLabel) { ctx.labeledTargets[ctx.pendingLabel] = { break: after, continue: null }; ctx.pendingLabel = null }`
+
+Replace `processBreak` and `processContinue`:
+
+```ts
+function processBreak(node: any, ctx: TraversalContext): BlockResult {
+  const n = ctx.graph.createNode('process', node.label ? `break ${node.label.name}` : 'break', 'rectangle')
+  const target = node.label ? ctx.labeledTargets[node.label.name]?.break ?? ctx.breakTarget : ctx.breakTarget
+  if (target) ctx.graph.connect(n, target)
+  return { entry: n, exit: null }
+}
+
+function processContinue(node: any, ctx: TraversalContext): BlockResult {
+  const n = ctx.graph.createNode('process', node.label ? `continue ${node.label.name}` : 'continue', 'rectangle')
+  const target = node.label ? ctx.labeledTargets[node.label.name]?.continue ?? ctx.continueTarget : ctx.continueTarget
+  if (target) ctx.graph.connect(n, target)
+  return { entry: n, exit: null }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx jest __tests__/parser-js-accuracy.test.ts __tests__/parser.test.ts`
+Expected: all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/parser/types.ts lib/parser/javascript.ts __tests__/parser-js-accuracy.test.ts
+git commit -m "fix(parser): support labeled statements and labeled break/continue"
+```
+
+---
+
+### Task 5: `throw` routes to the enclosing catch (fix 5, JS half)
+
+**Files:**
+- Modify: `lib/parser/types.ts` (`TraversalContext`)
+- Modify: `lib/parser/javascript.ts` (`processTry` ~line 223, `processThrow` ~line 275, `processFunctionBody` from Task 1)
+- Test: `__tests__/parser-js-accuracy.test.ts`
+
+**Interfaces:**
+- Produces on `TraversalContext`: `throwTarget: FlowchartNode | null` (copied by `clone()`) — Part 2's Python raise-routing task consumes this.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+describe('fix 5: throw routes to catch', () => {
+  test('throw inside try connects to the catch node', () => {
+    const code = "try {\n  if (bad) throw new Error('x')\n  ok()\n} catch (e) {\n  handle(e)\n}"
+    const out = codeToMermaid(code, 'javascript')
+    const throwId = out.match(/(N\d+)\["throw new Error\('x'\)"\]/)?.[1]
+    const catchId = out.match(/(N\d+)\(\["catch \(e\)"\]\)/)?.[1]
+    expect(throwId).toBeTruthy()
+    expect(catchId).toBeTruthy()
+    expect(out).toContain(`${throwId} --> ${catchId}`)
+  })
+
+  test('throw with no enclosing try stays terminal', () => {
+    const out = codeToMermaid("throw new Error('boom')", 'javascript')
+    const throwId = out.match(/(N\d+)\["throw new Error\('boom'\)"\]/)?.[1]
+    expect(out).not.toMatch(new RegExp(`${throwId} --> `))
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx jest __tests__/parser-js-accuracy.test.ts -t "fix 5"`
+Expected: first test FAILs (throw node has no outgoing edge).
+
+- [ ] **Step 3: Implement**
+
+`lib/parser/types.ts` — add to `TraversalContext`: `throwTarget: FlowchartNode | null = null`, and in `clone()`: `ctx.throwTarget = this.throwTarget`.
+
+`lib/parser/javascript.ts` — in `processFunctionBody`, next to the break/continue resets add `fCtx.throwTarget = null` (a function's throw fires at call time, not where it's defined).
+
+Replace `processTry` — the catch/finally nodes are now created **before** the try body is walked so the body's context can point at them:
+
+```ts
+function processTry(node: any, ctx: TraversalContext): BlockResult {
+  const tryNode = ctx.graph.createNode('process', 'try', 'rounded')
+  const after   = ctx.graph.createNode('merge' as any, '', 'circle')
+
+  let catchNode: FlowchartNode | null = null
+  if (node.handler) {
+    const param = node.handler.param ? formatExpression(node.handler.param) : 'error'
+    catchNode = ctx.graph.createNode('process', `catch (${param})`, 'rounded')
+    ctx.graph.connect(tryNode, catchNode, 'error')
+  }
+  const finallyNode: FlowchartNode | null = node.finalizer
+    ? ctx.graph.createNode('process', 'finally', 'rounded')
+    : null
+
+  const tCtx = ctx.clone(); tCtx.currentNode = tryNode
+  tCtx.throwTarget = catchNode ?? finallyNode
+  const tryRes = processBlock(node.block.body, tCtx)
+  if (tryRes.entry) ctx.graph.connect(tryNode, tryRes.entry)
+
+  if (finallyNode) {
+    const fCtx = ctx.clone(); fCtx.currentNode = finallyNode
+    const fRes = processBlock(node.finalizer.body, fCtx)
+    if (fRes.entry) ctx.graph.connect(finallyNode, fRes.entry)
+    ctx.graph.connect(fRes.exit ?? finallyNode, after)
+  }
+
+  const target = finallyNode ?? after
+  if (tryRes.exit) ctx.graph.connect(tryRes.exit, target)
+
+  if (catchNode) {
+    const cCtx = ctx.clone(); cCtx.currentNode = catchNode
+    const cRes = processBlock(node.handler.body.body, cCtx)
+    if (cRes.entry) ctx.graph.connect(catchNode, cRes.entry)
+    ctx.graph.connect(cRes.exit ?? catchNode, target)
+  }
+
+  return { entry: tryNode, exit: after }
+}
+```
+
+(Note: the catch body's context clones from the **outer** ctx, so a throw inside catch correctly propagates outward, not back into the same catch.)
+
+Replace `processThrow`:
+
+```ts
+function processThrow(node: any, ctx: TraversalContext): BlockResult {
+  const n = ctx.graph.createNode('process', `throw ${formatExpression(node.argument)}`, 'rectangle')
+  if (ctx.throwTarget) ctx.graph.connect(n, ctx.throwTarget)
+  return { entry: n, exit: null }
+}
+```
+
+- [ ] **Step 4: Run the full suite**
+
+Run: `npx jest`
+Expected: all suites PASS (node-creation order inside try changed; existing tests assert labels, not ids).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/parser/types.ts lib/parser/javascript.ts __tests__/parser-js-accuracy.test.ts
+git commit -m "fix(parser): route throw statements to the enclosing catch"
+```

--- a/docs/superpowers/plans/2026-07-10-parser-accuracy-part2-python.md
+++ b/docs/superpowers/plans/2026-07-10-parser-accuracy-part2-python.md
@@ -1,0 +1,694 @@
+# Parser Accuracy Part 2 (Python) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix the 5 confirmed Python conversion-accuracy defects plus the Python half of throw-routing (spec: `docs/superpowers/specs/2026-07-10-parser-accuracy-design.md` fixes 5–10).
+
+**Architecture:** Add a logical-line scanner (`python-lines.ts`) that joins bracket/backslash/triple-quote continuations and strips comments; restructure `parsePython` to split inline suites at the top-level colon and to attach `else`/`elif` to the **last** statement of the parent block; rework `processTry` for `try/else` and raise-routing.
+
+**Tech Stack:** TypeScript, jest (`npx jest`). Tests import via `@/lib/parser`.
+
+## Global Constraints
+
+- **Requires Part 1 complete** — `TraversalContext.throwTarget` (added in Part 1 Task 5) is consumed here.
+- No new dependencies.
+- Only touch: `lib/parser/python.ts`, new `lib/parser/python-lines.ts`, new test files `__tests__/python-lines.test.ts`, `__tests__/parser-python-accuracy.test.ts`.
+- `convertPython` must never throw: the scanner is total — unclosed brackets/strings at EOF flush the pending logical line as-is.
+- Existing tests must keep passing (`npx jest`).
+- Mermaid labels are escaped by `converter.ts` (`>` → `&gt;`, `"` → `'`) — test expectations must use the escaped form.
+- Commit messages: conventional style, **no Co-Authored-By trailer**.
+
+---
+
+### Task 1: Logical-line scanner (fix 7)
+
+**Files:**
+- Create: `lib/parser/python-lines.ts`
+- Modify: `lib/parser/python.ts` (delete its local `getIndent`, import from `./python-lines`; rewrite `parsePython`'s line loop)
+- Test: `__tests__/python-lines.test.ts` (create), `__tests__/parser-python-accuracy.test.ts` (create)
+
+**Interfaces:**
+- Produces (all exported from `lib/parser/python-lines.ts`; Tasks 2+ consume them):
+  - `interface LogicalLine { text: string; indent: number; lineNum: number }`
+  - `toLogicalLines(code: string): LogicalLine[]`
+  - `topLevelIndexOf(text: string, target: string, from?: number): number`
+  - `splitTopLevel(text: string, sep: string): string[]`
+  - `getIndent(line: string): number` (moved verbatim from python.ts)
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `__tests__/python-lines.test.ts`:
+
+```ts
+import { toLogicalLines, topLevelIndexOf, splitTopLevel } from '@/lib/parser/python-lines'
+
+describe('toLogicalLines', () => {
+  test('joins bracket continuations into one logical line', () => {
+    const out = toLogicalLines('result = compute(\n    alpha,\n    beta,\n)\nprint(result)')
+    expect(out.map(l => l.text)).toEqual(['result = compute( alpha, beta, )', 'print(result)'])
+    expect(out[0].indent).toBe(0)
+    expect(out[0].lineNum).toBe(1)
+  })
+
+  test('joins backslash continuations', () => {
+    const out = toLogicalLines('total = a + \\\n    b')
+    expect(out.map(l => l.text)).toEqual(['total = a + b'])
+  })
+
+  test('strips comments outside strings only', () => {
+    const out = toLogicalLines('x = "a # b"  # real comment\n# full-line comment\ny = 1')
+    expect(out.map(l => l.text)).toEqual(['x = "a # b"', 'y = 1'])
+  })
+
+  test('brackets inside strings do not open continuations', () => {
+    const out = toLogicalLines('msg = "if you see this: fine ("\nprint(msg)')
+    expect(out).toHaveLength(2)
+  })
+
+  test('triple-quoted string spanning lines stays one logical line', () => {
+    const out = toLogicalLines('doc = """line one\nline two"""\nprint(doc)')
+    expect(out).toHaveLength(2)
+    expect(out[0].text).toContain('line two')
+  })
+
+  test('unclosed bracket at EOF still flushes', () => {
+    const out = toLogicalLines('x = f(\n    1,')
+    expect(out).toHaveLength(1)
+  })
+})
+
+describe('topLevelIndexOf / splitTopLevel', () => {
+  test('skips colons inside brackets and strings', () => {
+    expect(topLevelIndexOf('if d[1:2] and "a:b": pass', ':')).toBe(19)
+    expect(topLevelIndexOf('x = 1', ':')).toBe(-1)
+  })
+
+  test('splits on top-level separators only', () => {
+    expect(splitTopLevel('a(); b("x;y"); c()', ';')).toEqual(['a()', ' b("x;y")', ' c()'])
+  })
+})
+```
+
+Create `__tests__/parser-python-accuracy.test.ts`:
+
+```ts
+import { codeToMermaid } from '@/lib/parser'
+
+describe('fix 7: multi-line statements', () => {
+  test('call split across lines renders as one node', () => {
+    const out = codeToMermaid('result = compute(\n    alpha,\n    beta,\n)\nprint(result)', 'python')
+    expect(out).toContain('result = compute( alpha, beta, )')
+    expect(out).not.toContain('["alpha,"]')
+  })
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx jest __tests__/python-lines.test.ts __tests__/parser-python-accuracy.test.ts`
+Expected: python-lines suite fails at import (module doesn't exist); accuracy test fails with four separate boxes.
+
+- [ ] **Step 3: Implement the scanner**
+
+Create `lib/parser/python-lines.ts`:
+
+```ts
+export interface LogicalLine { text: string; indent: number; lineNum: number }
+
+export function getIndent(line: string): number {
+  let n = 0
+  for (const c of line) { if (c === ' ') n++; else if (c === '\t') n += 4; else break }
+  return n
+}
+
+/**
+ * Joins physical lines into logical lines: open brackets, trailing-backslash
+ * continuations, and triple-quoted strings all continue onto the next line.
+ * Comments are stripped only outside strings. Total: unclosed state at EOF
+ * flushes the pending logical line instead of erroring.
+ */
+export function toLogicalLines(code: string): LogicalLine[] {
+  const physical = code.split('\n')
+  const out: LogicalLine[] = []
+  let buf: string[] = []
+  let indent = 0
+  let lineNum = 0
+  let depth = 0
+  let str: string | null = null // open string delimiter: ', ", ''' or """
+
+  const flush = () => {
+    const text = buf.join(' ').trim()
+    if (text) out.push({ text, indent, lineNum })
+    buf = []
+  }
+
+  for (let i = 0; i < physical.length; i++) {
+    const raw = physical[i]
+    if (buf.length === 0 && str === null) {
+      if (!raw.trim() || raw.trim().startsWith('#')) continue
+      indent = getIndent(raw)
+      lineNum = i + 1
+    }
+
+    let piece = ''
+    for (let j = 0; j < raw.length; j++) {
+      const c = raw[j]
+      if (str !== null) {
+        piece += c
+        if (str.length === 3) {
+          if (raw.startsWith(str, j)) { piece += str.slice(1); j += 2; str = null }
+        } else if (c === '\\') { piece += raw[j + 1] ?? ''; j++ }
+        else if (c === str) str = null
+        continue
+      }
+      if (c === '#') break
+      if (c === "'" || c === '"') {
+        if (raw.startsWith(c.repeat(3), j)) { str = c.repeat(3); piece += str; j += 2 }
+        else { str = c; piece += c }
+        continue
+      }
+      if ('([{'.includes(c)) depth++
+      else if (')]}'.includes(c)) depth = Math.max(0, depth - 1)
+      piece += c
+    }
+
+    // a single-quoted string cannot span physical lines — recover
+    if (str !== null && str.length === 1) str = null
+
+    const continued = piece.trimEnd().endsWith('\\')
+    buf.push((continued ? piece.trimEnd().slice(0, -1) : piece).trim())
+
+    if (depth === 0 && str === null && !continued) flush()
+  }
+  flush()
+  return out
+}
+
+/** Index of the first `target` char at bracket-depth 0 outside strings, at or after `from`. */
+export function topLevelIndexOf(text: string, target: string, from = 0): number {
+  let depth = 0
+  let str: string | null = null
+  for (let j = 0; j < text.length; j++) {
+    const c = text[j]
+    if (str !== null) {
+      if (str.length === 3) { if (text.startsWith(str, j)) { j += 2; str = null } }
+      else if (c === '\\') j++
+      else if (c === str) str = null
+      continue
+    }
+    if (c === "'" || c === '"') { str = text.startsWith(c.repeat(3), j) ? c.repeat(3) : c; if (str.length === 3) j += 2; continue }
+    if ('([{'.includes(c)) depth++
+    else if (')]}'.includes(c)) depth = Math.max(0, depth - 1)
+    else if (c === target && depth === 0 && j >= from) return j
+  }
+  return -1
+}
+
+/** Splits on `sep` occurring at bracket-depth 0 outside strings; drops empty parts. */
+export function splitTopLevel(text: string, sep: string): string[] {
+  const parts: string[] = []
+  let start = 0
+  let idx = topLevelIndexOf(text, sep, 0)
+  while (idx !== -1) {
+    parts.push(text.slice(start, idx))
+    start = idx + 1
+    idx = topLevelIndexOf(text, sep, start)
+  }
+  parts.push(text.slice(start))
+  return parts.filter(p => p.trim())
+}
+```
+
+In `lib/parser/python.ts`: delete the local `getIndent`, add `import { toLogicalLines } from './python-lines'` (Task 2 extends this import with `topLevelIndexOf, splitTopLevel`), and rewrite the loop head of `parsePython` — everything from `const lines = code.split('\n')` through the `const indent = getIndent(raw)` line becomes:
+
+```ts
+export function parsePython(code: string): PyNode {
+  const ast: PyNode = { type: 'Program', body: [] }
+  const stack: Array<{ indent: number; node: PyNode; type: string }> = [{ indent: -1, node: ast, type: 'program' }]
+
+  for (const ll of toLogicalLines(code)) {
+    const trimmed = ll.text
+    const indent = ll.indent
+
+    while (stack.length > 1 && indent <= stack[stack.length - 1].indent) stack.pop()
+    const parent = stack[stack.length - 1]
+    const node = parseLine(trimmed, ll.lineNum)
+    if (!node) continue
+    // ... rest of the loop body unchanged ...
+```
+
+(The rest of the loop — elif/else attach, except/finally attach, case attach, push — is unchanged in this task; `trimmed.endsWith(':')` still gates block-opening.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx jest __tests__/python-lines.test.ts __tests__/parser-python-accuracy.test.ts __tests__/parser.test.ts`
+Expected: all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/parser/python-lines.ts lib/parser/python.ts __tests__/python-lines.test.ts __tests__/parser-python-accuracy.test.ts
+git commit -m "fix(parser): join Python physical lines into logical lines before parsing"
+```
+
+---
+
+### Task 2: Inline suites + last-statement else/elif attachment (fixes 6 + 8 parse half)
+
+**Files:**
+- Modify: `lib/parser/python.ts` (`parsePython`)
+- Test: `__tests__/parser-python-accuracy.test.ts`
+
+**Interfaces:**
+- Consumes: `topLevelIndexOf`, `splitTopLevel` from Task 1.
+- Produces: `Try` PyNodes may now carry `elsebody: PyNode | null` (rendered in Task 3).
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `__tests__/parser-python-accuracy.test.ts`:
+
+```ts
+describe('fix 6: single-line suites', () => {
+  test('inline if body is kept', () => {
+    const out = codeToMermaid('x = 1\nif x > 0: print("positive")\nprint("done")', 'python')
+    expect(out).toContain('x &gt; 0?')
+    expect(out).toContain("print('positive')")
+    expect(out).toContain('-->|Yes|')
+  })
+
+  test('semicolon-separated inline suite renders every statement', () => {
+    const out = codeToMermaid('if flag: a(); b()', 'python')
+    expect(out).toContain('["a()"]')
+    expect(out).toContain('["b()"]')
+  })
+
+  test('colon inside a slice or string does not split the header', () => {
+    const out = codeToMermaid('for x in d[1:5]:\n    print(x)', 'python')
+    expect(out).toContain('x in d[1:5]?')
+    expect(out).toContain('print(x)')
+  })
+})
+
+describe('fix 8 (parse): else attaches to the nearest preceding block', () => {
+  test('else after try does not steal from an earlier if', () => {
+    const code = 'if a:\n    one()\ntry:\n    risky()\nexcept:\n    handle()\nelse:\n    ok()'
+    const out = codeToMermaid(code, 'python')
+    const aCond = out.match(/(N\d+)\{"a\?"\}/)?.[1]
+    const okId  = out.match(/(N\d+)\["ok\(\)"\]/)?.[1]
+    expect(okId).toBeTruthy()
+    // the if's No edge must not lead to ok()
+    expect(out).not.toContain(`${aCond} -->|No| ${okId}`)
+  })
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx jest __tests__/parser-python-accuracy.test.ts -t "fix 6"`
+Expected: FAIL — `print('positive')` missing (inline body dropped). The fix-8 test may pass or fail depending on current misattachment; keep it regardless.
+
+- [ ] **Step 3: Implement**
+
+Rewrite `parsePython` in `lib/parser/python.ts`:
+
+```ts
+const COMPOUND = /^(if|elif|else|for|while|def|class|try|except|finally|with|match|case)\b/
+
+export function parsePython(code: string): PyNode {
+  const ast: PyNode = { type: 'Program', body: [] }
+  const stack: Array<{ indent: number; node: PyNode; type: string }> = [{ indent: -1, node: ast, type: 'program' }]
+
+  for (const ll of toLogicalLines(code)) {
+    const trimmed = ll.text
+    const indent = ll.indent
+
+    while (stack.length > 1 && indent <= stack[stack.length - 1].indent) stack.pop()
+    const parent = stack[stack.length - 1]
+
+    let node: PyNode | null
+    let isBlock = false
+    if (COMPOUND.test(trimmed)) {
+      const ci = topLevelIndexOf(trimmed, ':')
+      if (ci !== -1 && ci < trimmed.length - 1) {
+        // inline suite: `if x: f(); g()` — parse header and remainder separately
+        node = parseLine(trimmed.slice(0, ci + 1), ll.lineNum)
+        const rest = trimmed.slice(ci + 1).trim()
+        if (node && rest) {
+          node.body = splitTopLevel(rest, ';')
+            .map(s => parseLine(s.trim(), ll.lineNum))
+            .filter((n): n is PyNode => !!n)
+        }
+      } else {
+        node = parseLine(trimmed, ll.lineNum)
+        isBlock = ci !== -1 // header with nothing after the colon opens a block
+      }
+    } else {
+      node = parseLine(trimmed, ll.lineNum)
+    }
+    if (!node) continue
+
+    // Attach elif/else to the LAST statement of the parent block only
+    if (node.type === 'Elif' || node.type === 'Else') {
+      const body = parent.node.body ?? []
+      const last = body[body.length - 1]
+      if (last && node.type === 'Elif' && last.type === 'If') {
+        const nested: PyNode = { type: 'If', test: node.test, body: node.body ?? [], orelse: [] }
+        const tail = getLastIf(last)
+        tail.orelse = tail.orelse ?? []
+        tail.orelse.push(nested)
+        if (isBlock) stack.push({ indent, node: nested, type: 'If' })
+        continue
+      }
+      if (last && node.type === 'Else') {
+        if (last.type === 'For' || last.type === 'While') last.orelse = node
+        else if (last.type === 'Try') last.elsebody = node
+        else if (last.type === 'If') { const tail = getLastIf(last); tail._elseNode = node }
+        else { continue } // stray else — drop
+        if (isBlock) stack.push({ indent, node, type: 'Else' })
+        continue
+      }
+      continue // stray elif/else with no preceding block — drop
+    }
+
+    // Attach except/finally to most recent try
+    if (node.type === 'ExceptHandler' || node.type === 'Finally') {
+      const body = parent.node.body ?? []
+      const tryNode = [...body].reverse().find((n: PyNode) => n.type === 'Try')
+      if (tryNode) {
+        if (node.type === 'ExceptHandler') tryNode.handlers.push(node)
+        else tryNode.finalbody = node
+        if (isBlock) stack.push({ indent, node, type: node.type })
+        continue
+      }
+    }
+
+    // Attach case to most recent match
+    if (node.type === 'Case') {
+      const body = parent.node.body ?? []
+      const matchNode = [...body].reverse().find((n: PyNode) => n.type === 'Match')
+      if (matchNode) {
+        matchNode.cases.push(node)
+        if (isBlock) stack.push({ indent, node, type: 'Case' })
+        continue
+      }
+    }
+
+    parent.node.body = parent.node.body ?? []
+    parent.node.body.push(node)
+    if (isBlock) stack.push({ indent, node, type: node.type })
+  }
+
+  return ast
+}
+```
+
+Notes:
+- `COMPOUND` uses `\b`, so `match = 5` or `case_count = 1` fall through to the plain-expression path (`topLevelIndexOf` returns -1 for them anyway).
+- `parseLine` itself is unchanged — headers passed to it still end with `:` so its regexes match.
+- The Elif branch also works for inline `elif b: two()` because `node.body` was filled before attachment.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx jest __tests__/parser-python-accuracy.test.ts __tests__/parser.test.ts`
+Expected: all PASS (the existing if/elif/else and try tests exercise the rewritten attach logic).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/parser/python.ts __tests__/parser-python-accuracy.test.ts
+git commit -m "fix(parser): parse Python inline suites and fix else/elif attachment"
+```
+
+---
+
+### Task 3: `try/else` rendering + raise routes to except (fixes 8 render + 5 Python half)
+
+**Files:**
+- Modify: `lib/parser/python.ts` (`processTry` ~line 224, `processRaise` ~line 295, `processFunction` ~line 149)
+- Test: `__tests__/parser-python-accuracy.test.ts`
+
+**Interfaces:**
+- Consumes: `TraversalContext.throwTarget` (Part 1 Task 5) and `Try.elsebody` (Task 2).
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+describe('fix 8 (render): try/except/else', () => {
+  test('else block runs after try body succeeds', () => {
+    const code = 'try:\n    risky()\nexcept ValueError:\n    handle()\nelse:\n    celebrate()\nprint("done")'
+    const out = codeToMermaid(code, 'python')
+    const riskyId = out.match(/(N\d+)\["risky\(\)"\]/)?.[1]
+    const celebId = out.match(/(N\d+)\["celebrate\(\)"\]/)?.[1]
+    expect(celebId).toBeTruthy()
+    expect(out).toContain(`${riskyId} --> ${celebId}`)
+  })
+})
+
+describe('fix 5 (python): raise routes to except', () => {
+  test('raise inside try connects to the first except node', () => {
+    const code = 'try:\n    if bad:\n        raise ValueError("x")\n    ok()\nexcept ValueError:\n    handle()'
+    const out = codeToMermaid(code, 'python')
+    const raiseId = out.match(/(N\d+)\["raise ValueError\('x'\)"\]/)?.[1]
+    const exceptId = out.match(/(N\d+)\(\["except ValueError"\]\)/)?.[1]
+    expect(raiseId).toBeTruthy()
+    expect(exceptId).toBeTruthy()
+    expect(out).toContain(`${raiseId} --> ${exceptId}`)
+  })
+
+  test('raise with no enclosing try stays terminal', () => {
+    const out = codeToMermaid('raise RuntimeError("boom")', 'python')
+    const raiseId = out.match(/(N\d+)\["raise RuntimeError\('boom'\)"\]/)?.[1]
+    expect(out).not.toMatch(new RegExp(`${raiseId} --> `))
+  })
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx jest __tests__/parser-python-accuracy.test.ts -t "fix 8 (render)"` and `-t "fix 5 (python)"`
+Expected: FAIL — `celebrate()` absent; raise node has no outgoing edge.
+
+- [ ] **Step 3: Implement**
+
+Replace `processTry` in `lib/parser/python.ts` — handler nodes are created **before** the try body so raises can route to them; `elsebody` renders on the success path:
+
+```ts
+function processTry(node: PyNode, ctx: TraversalContext): BlockResult {
+  const tryNode = ctx.graph.createNode('process', 'try', 'rounded')
+  const after   = ctx.graph.createNode('merge' as any, '', 'circle')
+
+  const handlerNodes: FlowchartNode[] = []
+  for (const h of (node.handlers ?? [])) {
+    const label = h.exceptionType ? (h.name ? `except ${h.exceptionType} as ${h.name}` : `except ${h.exceptionType}`) : 'except'
+    const catchN = ctx.graph.createNode('process', label, 'rounded')
+    ctx.graph.connect(tryNode, catchN, 'error')
+    handlerNodes.push(catchN)
+  }
+  const finallyNode: FlowchartNode | null = node.finalbody?.body
+    ? ctx.graph.createNode('process', 'finally', 'rounded')
+    : null
+
+  const tCtx = ctx.clone(); tCtx.currentNode = tryNode
+  tCtx.throwTarget = handlerNodes[0] ?? finallyNode
+  const tRes = processBlock(node.body ?? [], tCtx)
+  if (tRes.entry) ctx.graph.connect(tryNode, tRes.entry)
+
+  if (finallyNode) {
+    const fCtx = ctx.clone(); fCtx.currentNode = finallyNode
+    const fRes = processBlock(node.finalbody!.body, fCtx)
+    if (fRes.entry) ctx.graph.connect(finallyNode, fRes.entry)
+    ctx.graph.connect(fRes.exit ?? finallyNode, after)
+  }
+
+  const target = finallyNode ?? after
+
+  // try/else runs only when the try body completed without raising
+  let successExit = tRes.exit
+  if (node.elsebody && successExit) {
+    const eCtx = ctx.clone(); eCtx.currentNode = null
+    const eRes = processBlock(node.elsebody.body ?? [], eCtx)
+    if (eRes.entry) { ctx.graph.connect(successExit, eRes.entry); successExit = eRes.exit }
+  }
+  if (successExit) ctx.graph.connect(successExit, target)
+
+  for (let i = 0; i < handlerNodes.length; i++) {
+    const h = (node.handlers ?? [])[i]
+    const cCtx = ctx.clone(); cCtx.currentNode = handlerNodes[i]
+    const cRes = processBlock(h.body ?? [], cCtx)
+    if (cRes.entry) ctx.graph.connect(handlerNodes[i], cRes.entry)
+    ctx.graph.connect(cRes.exit ?? handlerNodes[i], target)
+  }
+
+  return { entry: tryNode, exit: after }
+}
+```
+
+Replace `processRaise`:
+
+```ts
+function processRaise(node: PyNode, ctx: TraversalContext): BlockResult {
+  const n = ctx.graph.createNode('process', node.exception ? `raise ${node.exception}` : 'raise', 'rectangle')
+  if (ctx.throwTarget) ctx.graph.connect(n, ctx.throwTarget)
+  return { entry: n, exit: null }
+}
+```
+
+In `processFunction`, after `fCtx.returnTarget = end` add function-boundary resets (matching Part 1):
+
+```ts
+fCtx.breakTarget = null; fCtx.continueTarget = null; fCtx.throwTarget = null
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx jest __tests__/parser-python-accuracy.test.ts __tests__/parser.test.ts`
+Expected: all PASS (existing try/except/finally test asserts labels only).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/parser/python.ts __tests__/parser-python-accuracy.test.ts
+git commit -m "fix(parser): render Python try/else and route raise to except"
+```
+
+---
+
+### Task 4: `while ... else` renders (fix 9)
+
+**Files:**
+- Modify: `lib/parser/python.ts` (`processWhile` ~line 214)
+- Test: `__tests__/parser-python-accuracy.test.ts`
+
+**Interfaces:** none new (`While.orelse` already attached by `parsePython`).
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+describe('fix 9: while-else', () => {
+  test('else body renders on the No path', () => {
+    const code = 'while cond():\n    work()\nelse:\n    cleanup()\nprint("done")'
+    const out = codeToMermaid(code, 'python')
+    const condId = out.match(/(N\d+)\{"cond\(\)\?"\}/)?.[1]
+    const cleanId = out.match(/(N\d+)\["cleanup\(\)"\]/)?.[1]
+    expect(cleanId).toBeTruthy()
+    expect(out).toContain(`${condId} -->|No| ${cleanId}`)
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx jest __tests__/parser-python-accuracy.test.ts -t "fix 9"`
+Expected: FAIL — `cleanup()` absent.
+
+- [ ] **Step 3: Implement**
+
+In `processWhile`, replace the unconditional `ctx.graph.connect(cond, after, 'No')` with the same `orelse` handling `processFor` already has:
+
+```ts
+if (node.orelse?.body?.length) {
+  const eCtx = ctx.clone(); eCtx.currentNode = null
+  const eRes = processBlock(node.orelse.body, eCtx)
+  if (eRes.entry) { ctx.graph.connect(cond, eRes.entry, 'No'); if (eRes.exit) ctx.graph.connect(eRes.exit, after) }
+  else ctx.graph.connect(cond, after, 'No')
+} else ctx.graph.connect(cond, after, 'No')
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx jest __tests__/parser-python-accuracy.test.ts __tests__/parser.test.ts`
+Expected: all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/parser/python.ts __tests__/parser-python-accuracy.test.ts
+git commit -m "fix(parser): render Python while-else body"
+```
+
+---
+
+### Task 5: `async def` / `async for` / `async with` + def return annotations (fix 10)
+
+**Files:**
+- Modify: `lib/parser/python.ts` (`parseLine` ~line 14, `processFunction`, `processWith`)
+- Test: `__tests__/parser-python-accuracy.test.ts`
+
+**Interfaces:** `PyNode` gains optional `isAsync?: boolean`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+describe('fix 10: async constructs', () => {
+  test('async def renders its body with async label', () => {
+    const code = 'async def fetch(url):\n    if not url:\n        return None\n    return await get(url)'
+    const out = codeToMermaid(code, 'python')
+    expect(out).toContain('async def fetch(url)')
+    expect(out).toContain('not url?')
+  })
+
+  test('async with and async for parse as blocks', () => {
+    const code = 'async def main():\n    async with session() as s:\n        async for item in s.stream():\n            handle(item)'
+    const out = codeToMermaid(code, 'python')
+    expect(out).toContain('async with session() as s')
+    expect(out).toContain('item in s.stream()?')
+    expect(out).toContain('handle(item)')
+  })
+
+  test('def with return annotation parses', () => {
+    const code = 'def size(x) -> int:\n    return len(x)'
+    const out = codeToMermaid(code, 'python')
+    expect(out).toContain('def size(x)')
+    expect(out).toContain('return len(x)')
+  })
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx jest __tests__/parser-python-accuracy.test.ts -t "fix 10"`
+Expected: FAIL — async lines and annotated defs fall through to plain `Expr` boxes; bodies flatten.
+
+- [ ] **Step 3: Implement**
+
+In `parseLine`, add as the **first** check (before the `def` regex):
+
+```ts
+if (line.startsWith('async ')) {
+  const node = parseLine(line.slice(6).trim(), lineNum)
+  if (node && (node.type === 'FunctionDef' || node.type === 'For' || node.type === 'With')) node.isAsync = true
+  return node
+}
+```
+
+Change the `def` regex to tolerate a return annotation:
+
+```ts
+if ((m = line.match(/^def\s+(\w+)\s*\((.*?)\)\s*(?:->\s*[^:]+)?:/)))
+```
+
+In `processFunction`, change the label line to:
+
+```ts
+const fn = ctx.graph.createNode('subroutine', `${node.isAsync ? 'async ' : ''}def ${node.name}(${node.params})`, 'rounded')
+```
+
+In `processWith`, change the label line to:
+
+```ts
+const w = ctx.graph.createNode('process', `${node.isAsync ? 'async ' : ''}with ${node.items}`, 'rounded')
+```
+
+(`async for` needs no label change — the loop diamond `item in s.stream()?` already reads naturally; the fix is that the body now parses. This is a deliberate refinement of the spec's "prepend async" wording for `for`.)
+
+- [ ] **Step 4: Run the full suite**
+
+Run: `npx jest`
+Expected: all suites PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/parser/python.ts __tests__/parser-python-accuracy.test.ts
+git commit -m "fix(parser): support Python async constructs and def return annotations"
+```

--- a/docs/superpowers/specs/2026-07-10-parser-accuracy-design.md
+++ b/docs/superpowers/specs/2026-07-10-parser-accuracy-design.md
@@ -1,0 +1,63 @@
+# Parser Accuracy Fixes — Design
+
+**Date:** 2026-07-10
+**Scope:** `lib/parser/` (javascript.ts, python.ts, types.ts). No UI, API, or converter changes expected (converter.ts only if a fix needs a new edge label).
+**Goal:** Fix 10 confirmed conversion-accuracy defects found by empirical audit, keeping the existing architecture: language parser → `FlowchartGraph` → Mermaid.
+
+## Confirmed defects
+
+| # | Lang | Defect |
+|---|------|--------|
+| 1 | JS/TS | Arrow-function / function-expression bodies render as one opaque box |
+| 2 | JS/TS | Classes render as a single node labeled "ClassDeclaration" |
+| 3 | JS/TS | `switch` without `default` has no "no match" exit edge — flow dead-ends |
+| 4 | JS/TS | Labeled statements render as one node "Labeled"; `break label` targets wrong loop |
+| 5 | JS/TS + Py | `throw`/`raise` inside `try` doesn't route to the handler (dead-end node) |
+| 6 | Py | Single-line suites (`if x: f()`) silently drop the body |
+| 7 | Py | Statements continued across physical lines shatter into one box per line |
+| 8 | Py | `try/except/else` — the `else` block vanishes |
+| 9 | Py | `while ... else` — the `else` body vanishes (`for ... else` already works) |
+| 10 | Py | `async def` / `async for` / `async with` not recognized; bodies flatten |
+
+## Design per fix
+
+### JavaScript / TypeScript (`javascript.ts`)
+
+**1. Function-valued expressions.** Extract a shared helper `processFunctionBody(label, bodyStatements, ctx)` from `processFunction` (creates subroutine + end node, sets `returnTarget`, walks body). Use it from:
+- `FunctionDeclaration` (as today),
+- `VariableDeclaration` declarators whose init is `ArrowFunctionExpression`/`FunctionExpression` with a **block body** — label `const add = (a, b) =>` / `function name(a, b)`; declarators are processed individually so mixed declarations still work,
+- `ExpressionStatement` assignments whose RHS is such a function (`obj.fn = function () {…}`).
+
+Expression-bodied arrows (`x => x * 2`) stay a single process node — no internal control flow to draw.
+
+**2. Classes.** Mirror Python's `processClass`: `ClassDeclaration`/`ClassExpression` renders a subroutine node `class Name` (with ` extends Base` when present), then each `MethodDefinition` body via `processFunctionBody` with label `name(params)` (`constructor(...)`, `get x()`, `static f()` prefixes preserved). Class fields render as one process node each; fields with function values go through fix 1's path.
+
+**3. Switch no-match edge.** In `processSwitch`, track whether a `default` case exists. If not, connect the switch decision → `after` merge with label `no match`.
+
+**4. Labeled statements.** Add `labeledTargets: Record<string, { break: FlowchartNode | null; continue: FlowchartNode | null }>` to `TraversalContext` (copied by spread in `clone()`), plus a transient `pendingLabel: string | null`. `LabeledStatement` sets `pendingLabel = label` and processes its body. Each loop processor (and `processSwitch`) registers its targets under `pendingLabel` (then clears it) before walking the body. `processBreak`/`processContinue` with a label resolve via `labeledTargets`, falling back to the unlabeled target.
+
+**5. Throw routing.** Add `throwTarget: FlowchartNode | null` to `TraversalContext`. `processTry` creates the catch node **before** walking the try body and sets `throwTarget` to it (or to the `finally` node when there is no handler) for the try-body context only. `processThrow` connects to `throwTarget` when set; with no enclosing try it stays a terminal node (uncaught throw = flow stops), unchanged from today. Python `processRaise` gets the identical treatment with `throwTarget` = first `except` handler node.
+
+### Python (`python.ts`)
+
+**7. Logical-line joining (done first — fixes 6 depends on its scanner).** New preprocessing step in `parsePython`: merge physical lines into logical lines before parsing. A small character scanner tracks bracket depth (`()[]{}`), string state (single/double quotes with escape handling, and triple-quoted strings), and trailing-backslash continuation. Lines are joined with a single space; indentation comes from the first physical line. `#` comments are stripped only when outside a string.
+
+**6. Single-line suites.** Compound headers (`if/elif/else/for/while/def/try/except/finally/with/class/match/case`) currently require the line to end with `:`. Using the same scanner, find the **top-level** colon that terminates the header. If non-comment text follows it (`if x > 0: print("hi")`), split the remainder on top-level `;`, parse each piece via `parseLine`, and attach them as the node's `body` (no stack push — the suite is complete inline).
+
+**8. try/except/else + misattachment.** Replace the "reverse-find an If/For/While" attachment logic for `Elif`/`Else` with: look at the **last** statement of the parent body and attach based on its type — `If` → `_elseNode` (via `getLastIf` tail), `For`/`While` → `orelse`, `Try` → new `elsebody` field. This both supports `try/else` and prevents an `else` from ever attaching to an earlier, unrelated `if`. Rendering: in `processTry`, the else block runs after the try body succeeds — `tryBody.exit → elseBlock → (finally ?? after)`; the handlers still connect straight to `(finally ?? after)`.
+
+**9. while-else.** `processWhile` handles `node.orelse` exactly as `processFor` already does: `cond —No→ elseBody → after`.
+
+**10. async.** In `parseLine`, if the trimmed line starts with `async `, strip the prefix, parse the remainder normally, and prepend `async ` to the rendered label for `def`/`for`/`with`.
+
+## Error handling
+
+No change to the public contract: `codeToMermaid(code, language)` still throws `Error` with a line number on unparseable JS/TS and never throws for Python (best-effort line parsing). The Python scanner must be total — unclosed brackets/strings at EOF flush the pending logical line as-is rather than erroring.
+
+## Testing
+
+Extend `__tests__/parser.test.ts` with one focused test per defect (10+), asserting on graph/Mermaid structure (e.g. "the arrow-function body's `if` produces a decision node", "switch decision has an edge to the merge when no default"). Existing tests must keep passing. Each fix is implemented test-first.
+
+## Out of scope
+
+Decorators, walrus operator, comprehension internals, Python `match` guard patterns, JS generators (`yield` control flow), replacing the Python line parser with a real AST parser, and any layout/rendering changes.

--- a/lib/parser/javascript.ts
+++ b/lib/parser/javascript.ts
@@ -59,6 +59,8 @@ function processFunctionBody(label: string, endLabel: string, bodyStatements: an
   // function boundary: enclosing loop targets don't apply inside the body
   fCtx.breakTarget = null
   fCtx.continueTarget = null
+  // a function's throw fires at call time, not where it's defined
+  fCtx.throwTarget = null
   const body = processBlock(bodyStatements, fCtx)
   if (body.entry) ctx.graph.connect(funcNode, body.entry)
   if (body.exit)  ctx.graph.connect(body.exit, endNode)
@@ -290,15 +292,27 @@ function processSwitch(node: any, ctx: TraversalContext): BlockResult {
 function processTry(node: any, ctx: TraversalContext): BlockResult {
   const tryNode = ctx.graph.createNode('process', 'try', 'rounded')
   const after   = ctx.graph.createNode('merge' as any, '', 'circle')
-  const tCtx    = ctx.clone(); tCtx.currentNode = tryNode
-  const tryRes  = processBlock(node.block.body, tCtx)
-  if (tryRes.entry) ctx.graph.connect(tryNode, tryRes.entry)
-  let finallyNode: FlowchartNode | null = null
 
-  if (node.finalizer) {
-    finallyNode = ctx.graph.createNode('process', 'finally', 'rounded')
-    const fCtx  = ctx.clone(); fCtx.currentNode = finallyNode
-    const fRes  = processBlock(node.finalizer.body, fCtx)
+  // catch/finally nodes are created before the try body is walked so the
+  // body's context can route throw statements to them
+  let catchNode: FlowchartNode | null = null
+  if (node.handler) {
+    const param = node.handler.param ? formatExpression(node.handler.param) : 'error'
+    catchNode = ctx.graph.createNode('process', `catch (${param})`, 'rounded')
+    ctx.graph.connect(tryNode, catchNode, 'error')
+  }
+  const finallyNode: FlowchartNode | null = node.finalizer
+    ? ctx.graph.createNode('process', 'finally', 'rounded')
+    : null
+
+  const tCtx = ctx.clone(); tCtx.currentNode = tryNode
+  tCtx.throwTarget = catchNode ?? finallyNode
+  const tryRes = processBlock(node.block.body, tCtx)
+  if (tryRes.entry) ctx.graph.connect(tryNode, tryRes.entry)
+
+  if (finallyNode) {
+    const fCtx = ctx.clone(); fCtx.currentNode = finallyNode
+    const fRes = processBlock(node.finalizer.body, fCtx)
     if (fRes.entry) ctx.graph.connect(finallyNode, fRes.entry)
     ctx.graph.connect(fRes.exit ?? finallyNode, after)
   }
@@ -306,15 +320,13 @@ function processTry(node: any, ctx: TraversalContext): BlockResult {
   const target = finallyNode ?? after
   if (tryRes.exit) ctx.graph.connect(tryRes.exit, target)
 
-  if (node.handler) {
-    const param    = node.handler.param ? formatExpression(node.handler.param) : 'error'
-    const catchNode = ctx.graph.createNode('process', `catch (${param})`, 'rounded')
-    ctx.graph.connect(tryNode, catchNode, 'error')
+  if (catchNode) {
+    // clones from the outer ctx so a throw inside catch propagates outward,
+    // not back into the same catch
     const cCtx = ctx.clone(); cCtx.currentNode = catchNode
     const cRes = processBlock(node.handler.body.body, cCtx)
     if (cRes.entry) ctx.graph.connect(catchNode, cRes.entry)
-    if (cRes.exit)  ctx.graph.connect(cRes.exit, target)
-    else ctx.graph.connect(catchNode, target)
+    ctx.graph.connect(cRes.exit ?? catchNode, target)
   }
 
   return { entry: tryNode, exit: after }
@@ -343,6 +355,7 @@ function processContinue(node: any, ctx: TraversalContext): BlockResult {
 
 function processThrow(node: any, ctx: TraversalContext): BlockResult {
   const n = ctx.graph.createNode('process', `throw ${formatExpression(node.argument)}`, 'rectangle')
+  if (ctx.throwTarget) ctx.graph.connect(n, ctx.throwTarget)
   return { entry: n, exit: null }
 }
 

--- a/lib/parser/javascript.ts
+++ b/lib/parser/javascript.ts
@@ -47,6 +47,32 @@ export function parseJS(code: string): acorn.Program {
   }
 }
 
+// ── Helper functions ────────────────────────────────────────────────────────
+
+function processFunctionBody(label: string, endLabel: string, bodyStatements: any[], ctx: TraversalContext): BlockResult {
+  const funcNode = ctx.graph.createNode('subroutine', label, 'rounded')
+  const endNode  = ctx.graph.createNode('process', endLabel, 'rounded')
+  const fCtx = ctx.clone()
+  fCtx.currentNode = funcNode
+  fCtx.returnTarget = endNode
+  // function boundary: enclosing loop targets don't apply inside the body
+  fCtx.breakTarget = null
+  fCtx.continueTarget = null
+  const body = processBlock(bodyStatements, fCtx)
+  if (body.entry) ctx.graph.connect(funcNode, body.entry)
+  if (body.exit)  ctx.graph.connect(body.exit, endNode)
+  return { entry: funcNode, exit: endNode }
+}
+
+function isBlockFunction(n: any): boolean {
+  return !!n && (n.type === 'ArrowFunctionExpression' || n.type === 'FunctionExpression') && n.body?.type === 'BlockStatement'
+}
+
+function functionLabel(prefix: string, fn: any): string {
+  const params = fn.params.map((p: any) => formatExpression(p)).join(', ')
+  return fn.type === 'ArrowFunctionExpression' ? `${prefix} = (${params}) =>` : `${prefix} = function(${params})`
+}
+
 // ── Statement handlers ───────────────────────────────────────────────────────
 
 export function processStatement(node: any, ctx: TraversalContext): BlockResult {
@@ -90,13 +116,7 @@ export function processStatement(node: any, ctx: TraversalContext): BlockResult 
 function processFunction(node: any, ctx: TraversalContext): BlockResult {
   const name = node.id?.name ?? 'anonymous'
   const params = node.params.map((p: any) => formatExpression(p)).join(', ')
-  const funcNode = ctx.graph.createNode('subroutine', `function ${name}(${params})`, 'rounded')
-  const endNode  = ctx.graph.createNode('process', `end ${name}`, 'rounded')
-  const fCtx = ctx.clone(); fCtx.currentNode = funcNode; fCtx.returnTarget = endNode
-  const body = processBlock(node.body.body, fCtx)
-  if (body.entry) ctx.graph.connect(funcNode, body.entry)
-  if (body.exit)  ctx.graph.connect(body.exit, endNode)
-  return { entry: funcNode, exit: endNode }
+  return processFunctionBody(`function ${name}(${params})`, `end ${name}`, node.body.body, ctx)
 }
 
 function processIf(node: any, ctx: TraversalContext): BlockResult {
@@ -278,16 +298,42 @@ function processThrow(node: any, ctx: TraversalContext): BlockResult {
 }
 
 function processVariable(node: any, ctx: TraversalContext): BlockResult {
-  const decls = node.declarations.map((d: any) => {
+  if (!node.declarations.some((d: any) => isBlockFunction(d.init))) {
+    const decls = node.declarations.map((d: any) => {
+      const name = formatExpression(d.id)
+      return d.init ? `${name} = ${formatExpression(d.init)}` : name
+    }).join(', ')
+    const n = ctx.graph.createNode('process', `${node.kind} ${decls}`, 'rectangle')
+    return { entry: n, exit: n }
+  }
+  // At least one declarator holds a function with a block body: render each
+  // declarator separately so the function's control flow stays visible.
+  let first: FlowchartNode | null = null
+  let prev: FlowchartNode | null = null
+  for (const d of node.declarations) {
     const name = formatExpression(d.id)
-    return d.init ? `${name} = ${formatExpression(d.init)}` : name
-  }).join(', ')
-  const n = ctx.graph.createNode('process', `${node.kind} ${decls}`, 'rectangle')
-  return { entry: n, exit: n }
+    let r: BlockResult
+    if (isBlockFunction(d.init)) {
+      r = processFunctionBody(functionLabel(`${node.kind} ${name}`, d.init), `end ${name}`, d.init.body.body, ctx)
+    } else {
+      const label = d.init ? `${node.kind} ${name} = ${formatExpression(d.init)}` : `${node.kind} ${name}`
+      const n = ctx.graph.createNode('process', label, 'rectangle')
+      r = { entry: n, exit: n }
+    }
+    if (!first) first = r.entry
+    if (prev && r.entry) ctx.graph.connect(prev, r.entry)
+    prev = r.exit
+  }
+  return { entry: first, exit: prev }
 }
 
 function processExpression(node: any, ctx: TraversalContext): BlockResult {
-  const n = ctx.graph.createNode('process', formatExpression(node.expression), 'rectangle')
+  const expr = node.expression
+  if (expr.type === 'AssignmentExpression' && expr.operator === '=' && isBlockFunction(expr.right)) {
+    const target = formatExpression(expr.left)
+    return processFunctionBody(functionLabel(target, expr.right), `end ${target}`, expr.right.body.body, ctx)
+  }
+  const n = ctx.graph.createNode('process', formatExpression(expr), 'rectangle')
   return { entry: n, exit: n }
 }
 

--- a/lib/parser/javascript.ts
+++ b/lib/parser/javascript.ts
@@ -126,6 +126,11 @@ export function processStatement(node: any, ctx: TraversalContext): BlockResult 
     case 'ExpressionStatement': return processExpression(node, ctx)
     case 'EmptyStatement':      return { entry: null, exit: ctx.currentNode }
     case 'ClassDeclaration':    return processClassJS(node, ctx)
+    case 'LabeledStatement': {
+      const lCtx = ctx.clone()
+      lCtx.pendingLabel = node.label.name
+      return processStatement(node.body, lCtx)
+    }
     // TypeScript: unwrap exports so the exported declaration still renders
     case 'ExportNamedDeclaration':
     case 'ExportDefaultDeclaration':
@@ -192,6 +197,7 @@ function processFor(node: any, ctx: TraversalContext): BlockResult {
   const update = node.update ? ctx.graph.createNode('process', formatExpression(node.update), 'rectangle') : null
   if (initNode) ctx.graph.connect(initNode, cond)
 
+  if (ctx.pendingLabel) { ctx.labeledTargets[ctx.pendingLabel] = { break: after, continue: update ?? cond }; ctx.pendingLabel = null }
   const loopCtx = ctx.clone(); loopCtx.currentNode = cond
   loopCtx.breakTarget = after; loopCtx.continueTarget = update ?? cond
   const body = node.body.type === 'BlockStatement' ? node.body.body : [node.body]
@@ -212,6 +218,7 @@ function processFor(node: any, ctx: TraversalContext): BlockResult {
 function processWhile(node: any, ctx: TraversalContext): BlockResult {
   const cond  = ctx.graph.createNode('decision', formatExpression(node.test) + '?', 'diamond')
   const after = ctx.graph.createNode('merge' as any, '', 'circle')
+  if (ctx.pendingLabel) { ctx.labeledTargets[ctx.pendingLabel] = { break: after, continue: cond }; ctx.pendingLabel = null }
   const lCtx  = ctx.clone(); lCtx.currentNode = cond; lCtx.breakTarget = after; lCtx.continueTarget = cond
   const body  = node.body.type === 'BlockStatement' ? node.body.body : [node.body]
   const r     = processBlock(body, lCtx)
@@ -225,6 +232,7 @@ function processDoWhile(node: any, ctx: TraversalContext): BlockResult {
   const bodyStart = ctx.graph.createNode('process', 'do', 'rounded')
   const cond      = ctx.graph.createNode('decision', formatExpression(node.test) + '?', 'diamond')
   const after     = ctx.graph.createNode('merge' as any, '', 'circle')
+  if (ctx.pendingLabel) { ctx.labeledTargets[ctx.pendingLabel] = { break: after, continue: cond }; ctx.pendingLabel = null }
   const lCtx      = ctx.clone(); lCtx.currentNode = bodyStart; lCtx.breakTarget = after; lCtx.continueTarget = cond
   const body      = node.body.type === 'BlockStatement' ? node.body.body : [node.body]
   const r         = processBlock(body, lCtx)
@@ -240,6 +248,7 @@ function processForIn(node: any, ctx: TraversalContext): BlockResult {
   const kw    = node.type === 'ForOfStatement' ? 'of' : 'in'
   const cond  = ctx.graph.createNode('decision', `${left} ${kw} ${formatExpression(node.right)}?`, 'diamond')
   const after = ctx.graph.createNode('merge' as any, '', 'circle')
+  if (ctx.pendingLabel) { ctx.labeledTargets[ctx.pendingLabel] = { break: after, continue: cond }; ctx.pendingLabel = null }
   const lCtx  = ctx.clone(); lCtx.currentNode = cond; lCtx.breakTarget = after; lCtx.continueTarget = cond
   const body  = node.body.type === 'BlockStatement' ? node.body.body : [node.body]
   const r     = processBlock(body, lCtx)
@@ -253,6 +262,7 @@ function processSwitch(node: any, ctx: TraversalContext): BlockResult {
   const after = ctx.graph.createNode('merge' as any, '', 'circle')
   let fallthrough: FlowchartNode | null = null
 
+  if (ctx.pendingLabel) { ctx.labeledTargets[ctx.pendingLabel] = { break: after, continue: null }; ctx.pendingLabel = null }
   for (const c of node.cases) {
     const label    = c.test ? `case ${formatExpression(c.test)}` : 'default'
     const caseNode = ctx.graph.createNode('process', label, 'rectangle')
@@ -314,13 +324,15 @@ function processReturn(node: any, ctx: TraversalContext): BlockResult {
 
 function processBreak(node: any, ctx: TraversalContext): BlockResult {
   const n = ctx.graph.createNode('process', node.label ? `break ${node.label.name}` : 'break', 'rectangle')
-  if (ctx.breakTarget) ctx.graph.connect(n, ctx.breakTarget)
+  const target = node.label ? ctx.labeledTargets[node.label.name]?.break ?? ctx.breakTarget : ctx.breakTarget
+  if (target) ctx.graph.connect(n, target)
   return { entry: n, exit: null }
 }
 
 function processContinue(node: any, ctx: TraversalContext): BlockResult {
   const n = ctx.graph.createNode('process', node.label ? `continue ${node.label.name}` : 'continue', 'rectangle')
-  if (ctx.continueTarget) ctx.graph.connect(n, ctx.continueTarget)
+  const target = node.label ? ctx.labeledTargets[node.label.name]?.continue ?? ctx.continueTarget : ctx.continueTarget
+  if (target) ctx.graph.connect(n, target)
   return { entry: n, exit: null }
 }
 

--- a/lib/parser/javascript.ts
+++ b/lib/parser/javascript.ts
@@ -128,7 +128,7 @@ export function processStatement(node: any, ctx: TraversalContext): BlockResult 
     case 'ClassDeclaration':    return processClassJS(node, ctx)
     case 'LabeledStatement': {
       const lCtx = ctx.clone()
-      lCtx.pendingLabel = node.label.name
+      lCtx.pendingLabels = [...ctx.pendingLabels, node.label.name]
       return processStatement(node.body, lCtx)
     }
     // TypeScript: unwrap exports so the exported declaration still renders
@@ -197,7 +197,8 @@ function processFor(node: any, ctx: TraversalContext): BlockResult {
   const update = node.update ? ctx.graph.createNode('process', formatExpression(node.update), 'rectangle') : null
   if (initNode) ctx.graph.connect(initNode, cond)
 
-  if (ctx.pendingLabel) { ctx.labeledTargets[ctx.pendingLabel] = { break: after, continue: update ?? cond }; ctx.pendingLabel = null }
+  for (const l of ctx.pendingLabels) ctx.labeledTargets[l] = { break: after, continue: update ?? cond }
+  ctx.pendingLabels = []
   const loopCtx = ctx.clone(); loopCtx.currentNode = cond
   loopCtx.breakTarget = after; loopCtx.continueTarget = update ?? cond
   const body = node.body.type === 'BlockStatement' ? node.body.body : [node.body]
@@ -218,7 +219,8 @@ function processFor(node: any, ctx: TraversalContext): BlockResult {
 function processWhile(node: any, ctx: TraversalContext): BlockResult {
   const cond  = ctx.graph.createNode('decision', formatExpression(node.test) + '?', 'diamond')
   const after = ctx.graph.createNode('merge' as any, '', 'circle')
-  if (ctx.pendingLabel) { ctx.labeledTargets[ctx.pendingLabel] = { break: after, continue: cond }; ctx.pendingLabel = null }
+  for (const l of ctx.pendingLabels) ctx.labeledTargets[l] = { break: after, continue: cond }
+  ctx.pendingLabels = []
   const lCtx  = ctx.clone(); lCtx.currentNode = cond; lCtx.breakTarget = after; lCtx.continueTarget = cond
   const body  = node.body.type === 'BlockStatement' ? node.body.body : [node.body]
   const r     = processBlock(body, lCtx)
@@ -232,7 +234,8 @@ function processDoWhile(node: any, ctx: TraversalContext): BlockResult {
   const bodyStart = ctx.graph.createNode('process', 'do', 'rounded')
   const cond      = ctx.graph.createNode('decision', formatExpression(node.test) + '?', 'diamond')
   const after     = ctx.graph.createNode('merge' as any, '', 'circle')
-  if (ctx.pendingLabel) { ctx.labeledTargets[ctx.pendingLabel] = { break: after, continue: cond }; ctx.pendingLabel = null }
+  for (const l of ctx.pendingLabels) ctx.labeledTargets[l] = { break: after, continue: cond }
+  ctx.pendingLabels = []
   const lCtx      = ctx.clone(); lCtx.currentNode = bodyStart; lCtx.breakTarget = after; lCtx.continueTarget = cond
   const body      = node.body.type === 'BlockStatement' ? node.body.body : [node.body]
   const r         = processBlock(body, lCtx)
@@ -248,7 +251,8 @@ function processForIn(node: any, ctx: TraversalContext): BlockResult {
   const kw    = node.type === 'ForOfStatement' ? 'of' : 'in'
   const cond  = ctx.graph.createNode('decision', `${left} ${kw} ${formatExpression(node.right)}?`, 'diamond')
   const after = ctx.graph.createNode('merge' as any, '', 'circle')
-  if (ctx.pendingLabel) { ctx.labeledTargets[ctx.pendingLabel] = { break: after, continue: cond }; ctx.pendingLabel = null }
+  for (const l of ctx.pendingLabels) ctx.labeledTargets[l] = { break: after, continue: cond }
+  ctx.pendingLabels = []
   const lCtx  = ctx.clone(); lCtx.currentNode = cond; lCtx.breakTarget = after; lCtx.continueTarget = cond
   const body  = node.body.type === 'BlockStatement' ? node.body.body : [node.body]
   const r     = processBlock(body, lCtx)
@@ -262,7 +266,8 @@ function processSwitch(node: any, ctx: TraversalContext): BlockResult {
   const after = ctx.graph.createNode('merge' as any, '', 'circle')
   let fallthrough: FlowchartNode | null = null
 
-  if (ctx.pendingLabel) { ctx.labeledTargets[ctx.pendingLabel] = { break: after, continue: null }; ctx.pendingLabel = null }
+  for (const l of ctx.pendingLabels) ctx.labeledTargets[l] = { break: after, continue: null }
+  ctx.pendingLabels = []
   for (const c of node.cases) {
     const label    = c.test ? `case ${formatExpression(c.test)}` : 'default'
     const caseNode = ctx.graph.createNode('process', label, 'rectangle')

--- a/lib/parser/javascript.ts
+++ b/lib/parser/javascript.ts
@@ -268,6 +268,7 @@ function processSwitch(node: any, ctx: TraversalContext): BlockResult {
   }
 
   if (fallthrough) ctx.graph.connect(fallthrough, after)
+  if (!node.cases.some((c: any) => !c.test)) ctx.graph.connect(sw, after, 'no match')
   return { entry: sw, exit: after }
 }
 

--- a/lib/parser/javascript.ts
+++ b/lib/parser/javascript.ts
@@ -27,6 +27,7 @@ export function formatExpression(node: acorn.Node | null, maxLen = 60): string {
     case 'TemplateLiteral':    text = '`...`'; break
     case 'ArrowFunctionExpression': text = '() => {...}'; break
     case 'FunctionExpression': text = 'function() {...}'; break
+    case 'Super':              text = 'super'; break
     default: text = n.type ?? '[expr]'
   }
   return text.length > maxLen ? text.substring(0, maxLen - 3) + '...' : text
@@ -37,7 +38,7 @@ export function formatExpression(node: acorn.Node | null, maxLen = 60): string {
 export function parseJS(code: string): acorn.Program {
   try {
     return acorn.parse(code, {
-      ecmaVersion: 2020,
+      ecmaVersion: 'latest',
       sourceType: 'script',
       allowReturnOutsideFunction: true,
       allowAwaitOutsideFunction: true,
@@ -73,6 +74,35 @@ function functionLabel(prefix: string, fn: any): string {
   return fn.type === 'ArrowFunctionExpression' ? `${prefix} = (${params}) =>` : `${prefix} = function(${params})`
 }
 
+function processClassJS(node: any, ctx: TraversalContext): BlockResult {
+  const name = node.id?.name ?? 'anonymous'
+  const base = node.superClass ? ` extends ${formatExpression(node.superClass)}` : ''
+  const cls  = ctx.graph.createNode('subroutine', `class ${name}${base}`, 'rounded')
+  let prev: FlowchartNode = cls
+  for (const m of node.body.body) {
+    let r: BlockResult | null = null
+    if (m.type === 'MethodDefinition' && m.value?.body) {
+      const key = formatExpression(m.key)
+      const params = m.value.params.map((p: any) => formatExpression(p)).join(', ')
+      let label = `${key}(${params})`
+      if (m.kind === 'get') label = `get ${label}`
+      if (m.kind === 'set') label = `set ${label}`
+      if (m.static) label = `static ${label}`
+      r = processFunctionBody(label, `end ${key}`, m.value.body.body, ctx)
+    } else if (m.type === 'PropertyDefinition') {
+      const key = formatExpression(m.key)
+      if (isBlockFunction(m.value)) {
+        r = processFunctionBody(functionLabel(key, m.value), `end ${key}`, m.value.body.body, ctx)
+      } else {
+        const n = ctx.graph.createNode('process', m.value ? `${key} = ${formatExpression(m.value)}` : key, 'rectangle')
+        r = { entry: n, exit: n }
+      }
+    }
+    if (r?.entry) { ctx.graph.connect(prev, r.entry); prev = r.exit ?? prev }
+  }
+  return { entry: cls, exit: prev }
+}
+
 // ── Statement handlers ───────────────────────────────────────────────────────
 
 export function processStatement(node: any, ctx: TraversalContext): BlockResult {
@@ -95,6 +125,7 @@ export function processStatement(node: any, ctx: TraversalContext): BlockResult 
     case 'VariableDeclaration': return processVariable(node, ctx)
     case 'ExpressionStatement': return processExpression(node, ctx)
     case 'EmptyStatement':      return { entry: null, exit: ctx.currentNode }
+    case 'ClassDeclaration':    return processClassJS(node, ctx)
     // TypeScript: unwrap exports so the exported declaration still renders
     case 'ExportNamedDeclaration':
     case 'ExportDefaultDeclaration':
@@ -298,7 +329,7 @@ function processThrow(node: any, ctx: TraversalContext): BlockResult {
 }
 
 function processVariable(node: any, ctx: TraversalContext): BlockResult {
-  if (!node.declarations.some((d: any) => isBlockFunction(d.init))) {
+  if (!node.declarations.some((d: any) => isBlockFunction(d.init) || d.init?.type === 'ClassExpression')) {
     const decls = node.declarations.map((d: any) => {
       const name = formatExpression(d.id)
       return d.init ? `${name} = ${formatExpression(d.init)}` : name
@@ -306,14 +337,16 @@ function processVariable(node: any, ctx: TraversalContext): BlockResult {
     const n = ctx.graph.createNode('process', `${node.kind} ${decls}`, 'rectangle')
     return { entry: n, exit: n }
   }
-  // At least one declarator holds a function with a block body: render each
-  // declarator separately so the function's control flow stays visible.
+  // At least one declarator holds a function with a block body or class expression:
+  // render each declarator separately so the function's/class's control flow stays visible.
   let first: FlowchartNode | null = null
   let prev: FlowchartNode | null = null
   for (const d of node.declarations) {
     const name = formatExpression(d.id)
     let r: BlockResult
-    if (isBlockFunction(d.init)) {
+    if (d.init?.type === 'ClassExpression') {
+      r = processClassJS({ ...d.init, id: d.init.id ?? d.id }, ctx)
+    } else if (isBlockFunction(d.init)) {
       r = processFunctionBody(functionLabel(`${node.kind} ${name}`, d.init), `end ${name}`, d.init.body.body, ctx)
     } else {
       const label = d.init ? `${node.kind} ${name} = ${formatExpression(d.init)}` : `${node.kind} ${name}`

--- a/lib/parser/python-lines.ts
+++ b/lib/parser/python-lines.ts
@@ -1,0 +1,104 @@
+export interface LogicalLine { text: string; indent: number; lineNum: number }
+
+export function getIndent(line: string): number {
+  let n = 0
+  for (const c of line) { if (c === ' ') n++; else if (c === '\t') n += 4; else break }
+  return n
+}
+
+/**
+ * Joins physical lines into logical lines: open brackets, trailing-backslash
+ * continuations, and triple-quoted strings all continue onto the next line.
+ * Comments are stripped only outside strings. Total: unclosed state at EOF
+ * flushes the pending logical line instead of erroring.
+ */
+export function toLogicalLines(code: string): LogicalLine[] {
+  const physical = code.split('\n')
+  const out: LogicalLine[] = []
+  let buf: string[] = []
+  let indent = 0
+  let lineNum = 0
+  let depth = 0
+  let str: string | null = null // open string delimiter: ', ", ''' or """
+
+  const flush = () => {
+    const text = buf.join(' ').trim()
+    if (text) out.push({ text, indent, lineNum })
+    buf = []
+  }
+
+  for (let i = 0; i < physical.length; i++) {
+    const raw = physical[i]
+    if (buf.length === 0 && str === null) {
+      if (!raw.trim() || raw.trim().startsWith('#')) continue
+      indent = getIndent(raw)
+      lineNum = i + 1
+    }
+
+    let piece = ''
+    for (let j = 0; j < raw.length; j++) {
+      const c = raw[j]
+      if (str !== null) {
+        piece += c
+        if (str.length === 3) {
+          if (raw.startsWith(str, j)) { piece += str.slice(1); j += 2; str = null }
+        } else if (c === '\\') { piece += raw[j + 1] ?? ''; j++ }
+        else if (c === str) str = null
+        continue
+      }
+      if (c === '#') break
+      if (c === "'" || c === '"') {
+        if (raw.startsWith(c.repeat(3), j)) { str = c.repeat(3); piece += str; j += 2 }
+        else { str = c; piece += c }
+        continue
+      }
+      if ('([{'.includes(c)) depth++
+      else if (')]}'.includes(c)) depth = Math.max(0, depth - 1)
+      piece += c
+    }
+
+    // a single-quoted string cannot span physical lines — recover
+    if (str !== null && str.length === 1) str = null
+
+    const continued = piece.trimEnd().endsWith('\\')
+    buf.push((continued ? piece.trimEnd().slice(0, -1) : piece).trim())
+
+    if (depth === 0 && str === null && !continued) flush()
+  }
+  flush()
+  return out
+}
+
+/** Index of the first `target` char at bracket-depth 0 outside strings, at or after `from`. */
+export function topLevelIndexOf(text: string, target: string, from = 0): number {
+  let depth = 0
+  let str: string | null = null
+  for (let j = 0; j < text.length; j++) {
+    const c = text[j]
+    if (str !== null) {
+      if (str.length === 3) { if (text.startsWith(str, j)) { j += 2; str = null } }
+      else if (c === '\\') j++
+      else if (c === str) str = null
+      continue
+    }
+    if (c === "'" || c === '"') { str = text.startsWith(c.repeat(3), j) ? c.repeat(3) : c; if (str.length === 3) j += 2; continue }
+    if ('([{'.includes(c)) depth++
+    else if (')]}'.includes(c)) depth = Math.max(0, depth - 1)
+    else if (c === target && depth === 0 && j >= from) return j
+  }
+  return -1
+}
+
+/** Splits on `sep` occurring at bracket-depth 0 outside strings; drops empty parts. */
+export function splitTopLevel(text: string, sep: string): string[] {
+  const parts: string[] = []
+  let start = 0
+  let idx = topLevelIndexOf(text, sep, 0)
+  while (idx !== -1) {
+    parts.push(text.slice(start, idx))
+    start = idx + 1
+    idx = topLevelIndexOf(text, sep, start)
+  }
+  parts.push(text.slice(start))
+  return parts.filter(p => p.trim())
+}

--- a/lib/parser/python.ts
+++ b/lib/parser/python.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { FlowchartGraph, TraversalContext, type BlockResult, type FlowchartNode } from './types'
-import { toLogicalLines } from './python-lines'
+import { toLogicalLines, topLevelIndexOf, splitTopLevel } from './python-lines'
 
 // ── Tokenizer ────────────────────────────────────────────────────────────────
 
@@ -52,6 +52,8 @@ function getLastIf(node: PyNode): PyNode {
   return node
 }
 
+const COMPOUND = /^(if|elif|else|for|while|def|class|try|except|finally|with|match|case)\b/
+
 export function parsePython(code: string): PyNode {
   const ast: PyNode = { type: 'Program', body: [] }
   const stack: Array<{ indent: number; node: PyNode; type: string }> = [{ indent: -1, node: ast, type: 'program' }]
@@ -62,28 +64,50 @@ export function parsePython(code: string): PyNode {
 
     while (stack.length > 1 && indent <= stack[stack.length - 1].indent) stack.pop()
     const parent = stack[stack.length - 1]
-    const node   = parseLine(trimmed, ll.lineNum)
+
+    let node: PyNode | null
+    let isBlock = false
+    if (COMPOUND.test(trimmed)) {
+      const ci = topLevelIndexOf(trimmed, ':')
+      if (ci !== -1 && ci < trimmed.length - 1) {
+        // inline suite: `if x: f(); g()` — parse header and remainder separately
+        node = parseLine(trimmed.slice(0, ci + 1), ll.lineNum)
+        const rest = trimmed.slice(ci + 1).trim()
+        if (node && rest) {
+          node.body = splitTopLevel(rest, ';')
+            .map(s => parseLine(s.trim(), ll.lineNum))
+            .filter((n): n is PyNode => !!n)
+        }
+      } else {
+        node = parseLine(trimmed, ll.lineNum)
+        isBlock = ci !== -1 // header with nothing after the colon opens a block
+      }
+    } else {
+      node = parseLine(trimmed, ll.lineNum)
+    }
     if (!node) continue
 
-    // Attach elif/else to previous if
+    // Attach elif/else to the LAST statement of the parent block only
     if (node.type === 'Elif' || node.type === 'Else') {
       const body = parent.node.body ?? []
-      const last = [...body].reverse().find((n: PyNode) => n.type === 'If' || n.type === 'For' || n.type === 'While')
-      if (last) {
-        if (node.type === 'Elif') {
-          const nested: PyNode = { type: 'If', test: node.test, body: [], orelse: [] }
-          const tail = getLastIf(last.type === 'If' ? last : { type: 'If', orelse: [] })
-          tail.orelse = tail.orelse ?? []
-          tail.orelse.push(nested)
-          if (trimmed.endsWith(':')) stack.push({ indent, node: nested, type: 'If' })
-        } else {
-          // else — attach to if or loop
-          if (last.type === 'For' || last.type === 'While') { last.orelse = node }
-          else { const tail = getLastIf(last); tail._elseNode = node }
-          if (trimmed.endsWith(':')) stack.push({ indent, node, type: 'Else' })
-        }
+      const last = body[body.length - 1]
+      if (last && node.type === 'Elif' && last.type === 'If') {
+        const nested: PyNode = { type: 'If', test: node.test, body: node.body ?? [], orelse: [] }
+        const tail = getLastIf(last)
+        tail.orelse = tail.orelse ?? []
+        tail.orelse.push(nested)
+        if (isBlock) stack.push({ indent, node: nested, type: 'If' })
         continue
       }
+      if (last && node.type === 'Else') {
+        if (last.type === 'For' || last.type === 'While') last.orelse = node
+        else if (last.type === 'Try') last.elsebody = node
+        else if (last.type === 'If') { const tail = getLastIf(last); tail._elseNode = node }
+        else { continue } // stray else — drop
+        if (isBlock) stack.push({ indent, node, type: 'Else' })
+        continue
+      }
+      continue // stray elif/else with no preceding block — drop
     }
 
     // Attach except/finally to most recent try
@@ -93,7 +117,7 @@ export function parsePython(code: string): PyNode {
       if (tryNode) {
         if (node.type === 'ExceptHandler') tryNode.handlers.push(node)
         else tryNode.finalbody = node
-        if (trimmed.endsWith(':')) stack.push({ indent, node, type: node.type })
+        if (isBlock) stack.push({ indent, node, type: node.type })
         continue
       }
     }
@@ -104,14 +128,14 @@ export function parsePython(code: string): PyNode {
       const matchNode = [...body].reverse().find((n: PyNode) => n.type === 'Match')
       if (matchNode) {
         matchNode.cases.push(node)
-        if (trimmed.endsWith(':')) stack.push({ indent, node, type: 'Case' })
+        if (isBlock) stack.push({ indent, node, type: 'Case' })
         continue
       }
     }
 
     parent.node.body = parent.node.body ?? []
     parent.node.body.push(node)
-    if (trimmed.endsWith(':')) stack.push({ indent, node, type: node.type })
+    if (isBlock) stack.push({ indent, node, type: node.type })
   }
 
   return ast

--- a/lib/parser/python.ts
+++ b/lib/parser/python.ts
@@ -9,7 +9,12 @@ interface PyNode { type: string; body?: PyNode[]; [key: string]: any }
 function parseLine(line: string, lineNum: number): PyNode | null {
   let m: RegExpMatchArray | null
 
-  if ((m = line.match(/^def\s+(\w+)\s*\((.*?)\)\s*:/)))
+  if (line.startsWith('async ')) {
+    const node = parseLine(line.slice(6).trim(), lineNum)
+    if (node && (node.type === 'FunctionDef' || node.type === 'For' || node.type === 'With')) node.isAsync = true
+    return node
+  }
+  if ((m = line.match(/^def\s+(\w+)\s*\((.*?)\)\s*(?:->\s*[^:]+)?:/)))
     return { type: 'FunctionDef', name: m[1], params: m[2], body: [], line: lineNum }
   if ((m = line.match(/^class\s+(\w+)(?:\s*\((.*?)\))?\s*:/)))
     return { type: 'ClassDef', name: m[1], bases: m[2] ?? '', body: [], line: lineNum }
@@ -52,7 +57,7 @@ function getLastIf(node: PyNode): PyNode {
   return node
 }
 
-const COMPOUND = /^(if|elif|else|for|while|def|class|try|except|finally|with|match|case)\b/
+const COMPOUND = /^(?:async\s+)?(if|elif|else|for|while|def|class|try|except|finally|with|match|case)\b/
 
 export function parsePython(code: string): PyNode {
   const ast: PyNode = { type: 'Program', body: [] }
@@ -163,7 +168,7 @@ function processStatement(node: PyNode, ctx: TraversalContext): BlockResult {
 }
 
 function processFunction(node: PyNode, ctx: TraversalContext): BlockResult {
-  const fn  = ctx.graph.createNode('subroutine', `def ${node.name}(${node.params})`, 'rounded')
+  const fn  = ctx.graph.createNode('subroutine', `${node.isAsync ? 'async ' : ''}def ${node.name}(${node.params})`, 'rounded')
   const end = ctx.graph.createNode('process', `end ${node.name}`, 'rounded')
   const fCtx = ctx.clone(); fCtx.currentNode = fn; fCtx.returnTarget = end
   // function boundary: enclosing loop/try targets don't apply inside the body
@@ -296,7 +301,7 @@ function processTry(node: PyNode, ctx: TraversalContext): BlockResult {
 }
 
 function processWith(node: PyNode, ctx: TraversalContext): BlockResult {
-  const w    = ctx.graph.createNode('process', `with ${node.items}`, 'rounded')
+  const w    = ctx.graph.createNode('process', `${node.isAsync ? 'async ' : ''}with ${node.items}`, 'rounded')
   const wCtx = ctx.clone(); wCtx.currentNode = w
   const r    = processBlock(node.body ?? [], wCtx)
   if (r.entry) ctx.graph.connect(w, r.entry)

--- a/lib/parser/python.ts
+++ b/lib/parser/python.ts
@@ -1,15 +1,10 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { FlowchartGraph, TraversalContext, type BlockResult, type FlowchartNode } from './types'
+import { toLogicalLines } from './python-lines'
 
 // ── Tokenizer ────────────────────────────────────────────────────────────────
 
 interface PyNode { type: string; body?: PyNode[]; [key: string]: any }
-
-function getIndent(line: string): number {
-  let n = 0
-  for (const c of line) { if (c === ' ') n++; else if (c === '\t') n += 4; else break }
-  return n
-}
 
 function parseLine(line: string, lineNum: number): PyNode | null {
   let m: RegExpMatchArray | null
@@ -58,19 +53,16 @@ function getLastIf(node: PyNode): PyNode {
 }
 
 export function parsePython(code: string): PyNode {
-  const lines = code.split('\n')
   const ast: PyNode = { type: 'Program', body: [] }
   const stack: Array<{ indent: number; node: PyNode; type: string }> = [{ indent: -1, node: ast, type: 'program' }]
 
-  for (let i = 0; i < lines.length; i++) {
-    const raw = lines[i]
-    const trimmed = raw.trim()
-    if (!trimmed || trimmed.startsWith('#')) continue
-    const indent = getIndent(raw)
+  for (const ll of toLogicalLines(code)) {
+    const trimmed = ll.text
+    const indent = ll.indent
 
     while (stack.length > 1 && indent <= stack[stack.length - 1].indent) stack.pop()
     const parent = stack[stack.length - 1]
-    const node   = parseLine(trimmed, i + 1)
+    const node   = parseLine(trimmed, ll.lineNum)
     if (!node) continue
 
     // Attach elif/else to previous if

--- a/lib/parser/python.ts
+++ b/lib/parser/python.ts
@@ -166,6 +166,8 @@ function processFunction(node: PyNode, ctx: TraversalContext): BlockResult {
   const fn  = ctx.graph.createNode('subroutine', `def ${node.name}(${node.params})`, 'rounded')
   const end = ctx.graph.createNode('process', `end ${node.name}`, 'rounded')
   const fCtx = ctx.clone(); fCtx.currentNode = fn; fCtx.returnTarget = end
+  // function boundary: enclosing loop/try targets don't apply inside the body
+  fCtx.breakTarget = null; fCtx.continueTarget = null; fCtx.throwTarget = null
   const r = processBlock(node.body ?? [], fCtx)
   if (r.entry) ctx.graph.connect(fn, r.entry)
   if (r.exit)  ctx.graph.connect(r.exit, end)
@@ -240,30 +242,49 @@ function processWhile(node: PyNode, ctx: TraversalContext): BlockResult {
 function processTry(node: PyNode, ctx: TraversalContext): BlockResult {
   const tryNode = ctx.graph.createNode('process', 'try', 'rounded')
   const after   = ctx.graph.createNode('merge' as any, '', 'circle')
-  const tCtx    = ctx.clone(); tCtx.currentNode = tryNode
-  const tRes    = processBlock(node.body ?? [], tCtx)
-  if (tRes.entry) ctx.graph.connect(tryNode, tRes.entry)
-  let finallyNode: FlowchartNode | null = null
 
-  if (node.finalbody?.body) {
-    finallyNode = ctx.graph.createNode('process', 'finally', 'rounded')
-    const fCtx  = ctx.clone(); fCtx.currentNode = finallyNode
-    const fRes  = processBlock(node.finalbody.body, fCtx)
+  // handler nodes are created before the try body is walked so raises can
+  // route to them
+  const handlerNodes: FlowchartNode[] = []
+  for (const h of (node.handlers ?? [])) {
+    const label = h.exceptionType ? (h.name ? `except ${h.exceptionType} as ${h.name}` : `except ${h.exceptionType}`) : 'except'
+    const catchN = ctx.graph.createNode('process', label, 'rounded')
+    ctx.graph.connect(tryNode, catchN, 'error')
+    handlerNodes.push(catchN)
+  }
+  const finallyNode: FlowchartNode | null = node.finalbody?.body
+    ? ctx.graph.createNode('process', 'finally', 'rounded')
+    : null
+
+  const tCtx = ctx.clone(); tCtx.currentNode = tryNode
+  tCtx.throwTarget = handlerNodes[0] ?? finallyNode
+  const tRes = processBlock(node.body ?? [], tCtx)
+  if (tRes.entry) ctx.graph.connect(tryNode, tRes.entry)
+
+  if (finallyNode) {
+    const fCtx = ctx.clone(); fCtx.currentNode = finallyNode
+    const fRes = processBlock(node.finalbody!.body, fCtx)
     if (fRes.entry) ctx.graph.connect(finallyNode, fRes.entry)
     ctx.graph.connect(fRes.exit ?? finallyNode, after)
   }
 
   const target = finallyNode ?? after
-  if (tRes.exit) ctx.graph.connect(tRes.exit, target)
 
-  for (const h of (node.handlers ?? [])) {
-    const label   = h.exceptionType ? (h.name ? `except ${h.exceptionType} as ${h.name}` : `except ${h.exceptionType}`) : 'except'
-    const catchN  = ctx.graph.createNode('process', label, 'rounded')
-    ctx.graph.connect(tryNode, catchN, 'error')
-    const cCtx = ctx.clone(); cCtx.currentNode = catchN
+  // try/else runs only when the try body completed without raising
+  let successExit = tRes.exit
+  if (node.elsebody && successExit) {
+    const eCtx = ctx.clone(); eCtx.currentNode = null
+    const eRes = processBlock(node.elsebody.body ?? [], eCtx)
+    if (eRes.entry) { ctx.graph.connect(successExit, eRes.entry); successExit = eRes.exit }
+  }
+  if (successExit) ctx.graph.connect(successExit, target)
+
+  for (let i = 0; i < handlerNodes.length; i++) {
+    const h = (node.handlers ?? [])[i]
+    const cCtx = ctx.clone(); cCtx.currentNode = handlerNodes[i]
     const cRes = processBlock(h.body ?? [], cCtx)
-    if (cRes.entry) ctx.graph.connect(catchN, cRes.entry)
-    ctx.graph.connect(cRes.exit ?? catchN, target)
+    if (cRes.entry) ctx.graph.connect(handlerNodes[i], cRes.entry)
+    ctx.graph.connect(cRes.exit ?? handlerNodes[i], target)
   }
 
   return { entry: tryNode, exit: after }
@@ -310,6 +331,7 @@ function processContinue(node: PyNode, ctx: TraversalContext): BlockResult {
 }
 function processRaise(node: PyNode, ctx: TraversalContext): BlockResult {
   const n = ctx.graph.createNode('process', node.exception ? `raise ${node.exception}` : 'raise', 'rectangle')
+  if (ctx.throwTarget) ctx.graph.connect(n, ctx.throwTarget)
   return { entry: n, exit: null }
 }
 function processGeneric(node: PyNode, ctx: TraversalContext): BlockResult {

--- a/lib/parser/python.ts
+++ b/lib/parser/python.ts
@@ -235,7 +235,12 @@ function processWhile(node: PyNode, ctx: TraversalContext): BlockResult {
   const lCtx  = ctx.clone(); lCtx.currentNode = cond; lCtx.breakTarget = after; lCtx.continueTarget = cond
   const r     = processBlock(node.body ?? [], lCtx)
   if (r.entry) { ctx.graph.connect(cond, r.entry, 'Yes'); if (r.exit) ctx.graph.connect(r.exit, cond) }
-  ctx.graph.connect(cond, after, 'No')
+  if (node.orelse?.body?.length) {
+    const eCtx = ctx.clone(); eCtx.currentNode = null
+    const eRes = processBlock(node.orelse.body, eCtx)
+    if (eRes.entry) { ctx.graph.connect(cond, eRes.entry, 'No'); if (eRes.exit) ctx.graph.connect(eRes.exit, after) }
+    else ctx.graph.connect(cond, after, 'No')
+  } else ctx.graph.connect(cond, after, 'No')
   return { entry: cond, exit: after }
 }
 

--- a/lib/parser/types.ts
+++ b/lib/parser/types.ts
@@ -58,6 +58,8 @@ export class TraversalContext {
   breakTarget: FlowchartNode | null = null
   continueTarget: FlowchartNode | null = null
   returnTarget: FlowchartNode | null = null
+  labeledTargets: Record<string, { break: FlowchartNode | null; continue: FlowchartNode | null }> = {}
+  pendingLabel: string | null = null
 
   constructor(public graph: FlowchartGraph) {}
 
@@ -67,6 +69,8 @@ export class TraversalContext {
     ctx.breakTarget = this.breakTarget
     ctx.continueTarget = this.continueTarget
     ctx.returnTarget = this.returnTarget
+    ctx.labeledTargets = { ...this.labeledTargets }
+    ctx.pendingLabel = this.pendingLabel
     return ctx
   }
 }

--- a/lib/parser/types.ts
+++ b/lib/parser/types.ts
@@ -59,7 +59,7 @@ export class TraversalContext {
   continueTarget: FlowchartNode | null = null
   returnTarget: FlowchartNode | null = null
   labeledTargets: Record<string, { break: FlowchartNode | null; continue: FlowchartNode | null }> = {}
-  pendingLabel: string | null = null
+  pendingLabels: string[] = []
 
   constructor(public graph: FlowchartGraph) {}
 
@@ -70,7 +70,7 @@ export class TraversalContext {
     ctx.continueTarget = this.continueTarget
     ctx.returnTarget = this.returnTarget
     ctx.labeledTargets = { ...this.labeledTargets }
-    ctx.pendingLabel = this.pendingLabel
+    ctx.pendingLabels = [...this.pendingLabels]
     return ctx
   }
 }

--- a/lib/parser/types.ts
+++ b/lib/parser/types.ts
@@ -60,6 +60,7 @@ export class TraversalContext {
   returnTarget: FlowchartNode | null = null
   labeledTargets: Record<string, { break: FlowchartNode | null; continue: FlowchartNode | null }> = {}
   pendingLabels: string[] = []
+  throwTarget: FlowchartNode | null = null
 
   constructor(public graph: FlowchartGraph) {}
 
@@ -71,6 +72,7 @@ export class TraversalContext {
     ctx.returnTarget = this.returnTarget
     ctx.labeledTargets = { ...this.labeledTargets }
     ctx.pendingLabels = [...this.pendingLabels]
+    ctx.throwTarget = this.throwTarget
     return ctx
   }
 }


### PR DESCRIPTION
## Summary

  Fixes 10 conversion-accuracy defects in the code-to-flowchart parsers — 5 in JavaScript/TypeScript and 5 in Python — so generated flowcharts match how the code actually executes.

  ## JavaScript / TypeScript

  - **Function expressions** — arrow functions and function expressions assigned to variables or properties now render their bodies as subroutines instead of a single opaque box
  - **Classes** — class declarations render each method and field, instead of one `ClassDeclaration` box
  - **Switch** — a `switch` without a `default` now gets a `no match` exit edge, so flow visibly continues when no case matches
  - **Labels** — labeled statements are supported; `break label` / `continue label` jump to the correct loop (including doubly-labeled statements)
  - **Throw** — `throw` inside a `try` now connects to its `catch` handler instead of dead-ending

  ## Python

  - **Multi-line statements** — a new logical-line scanner joins bracket, backslash, and triple-quote continuations, so a call split across lines renders as one node
  - **Inline suites** — single-line bodies like `if x: f(); g()` are parsed instead of dropped
  - **else/elif attachment** — `else` now binds to the nearest preceding block, so an `else` after `try` no longer attaches to an earlier `if`
  - **try/else and raise** — `try/else` renders on the success path, and `raise` inside a `try` connects to its `except` handler
  - **while/else and async** — `while ... else` renders; `async def` / `async for` / `async with` and `def` return annotations parse correctly

  ## Testing

  - 34 new tests across 3 test files (47 total, all passing)
  - Every fix was written test-first against the exact Mermaid output
  - `tsc --noEmit` clean; no new dependencies