### PR TITLE
feat(ui): dark coding-platform design overhaul

### DIFF
--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react'
 import { useRouter } from 'next/navigation'
 import Link from 'next/link'
 import { createClient } from '@/lib/supabase/client'
-import { Eye, EyeOff, Loader2, AlertCircle } from 'lucide-react'
+import { Eye, EyeOff, Loader2, AlertCircle, Workflow } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
@@ -35,13 +35,16 @@ export default function LoginPage() {
   return (
     <div className="min-h-screen flex flex-col items-center justify-center bg-background">
       <DottedSurface />
-      <div className="text-center mb-8">
-        <Link href="/" className="text-2xl font-bold tracking-tight hover:opacity-80 transition-opacity duration-150">
+      <div className="relative text-center mb-8">
+        <Link href="/" className="inline-flex items-center gap-2 text-2xl font-bold tracking-tight hover:opacity-80 transition-opacity duration-150">
+          <span className="inline-flex items-center justify-center size-8 rounded-md bg-primary/15 text-primary">
+            <Workflow className="size-5" />
+          </span>
           Code2Flow
         </Link>
-        <p className="text-sm text-muted-foreground mt-1">Turn code into flowcharts</p>
+        <p className="text-sm text-muted-foreground mt-2">Turn code into flowcharts</p>
       </div>
-      <div className="w-full max-w-sm space-y-6 p-10 border border-t-2 border-t-primary/20 border-border ring-1 ring-border/40 shadow-xl rounded-lg bg-background">
+      <div className="relative w-full max-w-sm space-y-6 p-8 sm:p-10 border border-t-2 border-t-primary/40 border-border shadow-xl rounded-lg bg-card">
         <h1 className="text-xl font-semibold text-center">Sign in</h1>
         <form onSubmit={handleSubmit} className="space-y-4">
           <div className="space-y-1">

--- a/app/(auth)/register/page.tsx
+++ b/app/(auth)/register/page.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react'
 import { useRouter } from 'next/navigation'
 import Link from 'next/link'
 import { createClient } from '@/lib/supabase/client'
-import { Eye, EyeOff, Loader2, AlertCircle } from 'lucide-react'
+import { Eye, EyeOff, Loader2, AlertCircle, Workflow } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
@@ -40,13 +40,16 @@ export default function RegisterPage() {
   return (
     <div className="min-h-screen flex flex-col items-center justify-center bg-background">
       <DottedSurface />
-      <div className="text-center mb-8">
-        <Link href="/" className="text-2xl font-bold tracking-tight hover:opacity-80 transition-opacity duration-150">
+      <div className="relative text-center mb-8">
+        <Link href="/" className="inline-flex items-center gap-2 text-2xl font-bold tracking-tight hover:opacity-80 transition-opacity duration-150">
+          <span className="inline-flex items-center justify-center size-8 rounded-md bg-primary/15 text-primary">
+            <Workflow className="size-5" />
+          </span>
           Code2Flow
         </Link>
-        <p className="text-sm text-muted-foreground mt-1">Turn code into flowcharts</p>
+        <p className="text-sm text-muted-foreground mt-2">Turn code into flowcharts</p>
       </div>
-      <div className="w-full max-w-sm space-y-6 p-10 border border-t-2 border-t-primary/20 border-border ring-1 ring-border/40 shadow-xl rounded-lg bg-background">
+      <div className="relative w-full max-w-sm space-y-6 p-8 sm:p-10 border border-t-2 border-t-primary/40 border-border shadow-xl rounded-lg bg-card">
         <h1 className="text-xl font-semibold text-center">Create your account</h1>
         <form onSubmit={handleSubmit} className="space-y-4">
           <div className="space-y-1">

--- a/app/(protected)/dashboard/page.tsx
+++ b/app/(protected)/dashboard/page.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link'
-import { FileCode2 } from 'lucide-react'
+import { FileCode2, Plus } from 'lucide-react'
 import { createClient } from '@/lib/supabase/server'
 import { FlowchartCard } from '@/components/dashboard/FlowchartCard'
 import { Navbar } from '@/components/layout/Navbar'
@@ -20,18 +20,33 @@ export default async function DashboardPage() {
       <Navbar user={user} />
       <main className="max-w-6xl mx-auto px-4 py-8">
         <div className="flex items-center justify-between mb-8">
-          <h1 className="text-2xl font-semibold">My Flowcharts</h1>
+          <div>
+            <h1 className="text-2xl font-semibold tracking-tight">My Flowcharts</h1>
+            {flowcharts?.length ? (
+              <p className="text-sm text-muted-foreground mt-1">
+                {flowcharts.length} {flowcharts.length === 1 ? 'flowchart' : 'flowcharts'}
+              </p>
+            ) : null}
+          </div>
           <Link href="/editor">
-            <Button>New flowchart</Button>
+            <Button className="gap-1.5">
+              <Plus className="size-4" />
+              New flowchart
+            </Button>
           </Link>
         </div>
         {!flowcharts?.length ? (
-          <div className="flex flex-col items-center justify-center py-24 gap-3 text-center">
-            <FileCode2 className="size-12 text-muted-foreground/40" />
+          <div className="flex flex-col items-center justify-center py-24 gap-3 text-center border border-dashed border-border rounded-lg bg-card/40">
+            <div className="inline-flex items-center justify-center size-14 rounded-full bg-primary/10 text-primary mb-1">
+              <FileCode2 className="size-6" />
+            </div>
             <h2 className="text-base font-medium">Your canvas is empty</h2>
             <p className="text-sm text-muted-foreground">Create your first flowchart to get started.</p>
             <Link href="/editor" className="mt-2">
-              <Button>New flowchart</Button>
+              <Button className="gap-1.5">
+                <Plus className="size-4" />
+                New flowchart
+              </Button>
             </Link>
           </div>
         ) : (

--- a/app/globals.css
+++ b/app/globals.css
@@ -4,25 +4,25 @@
 
 @layer base {
   :root {
-    --background: 222.2 84% 4.9%;
+    --background: 224 60% 4%;
     --foreground: 210 40% 98%;
-    --card: 222.2 84% 4.9%;
+    --card: 223 45% 7%;
     --card-foreground: 210 40% 98%;
-    --popover: 222.2 84% 4.9%;
+    --popover: 223 45% 7%;
     --popover-foreground: 210 40% 98%;
-    --primary: 210 40% 98%;
-    --primary-foreground: 222.2 47.4% 11.2%;
+    --primary: 142 71% 45%;
+    --primary-foreground: 145 80% 5%;
     --secondary: 217.2 32.6% 17.5%;
     --secondary-foreground: 210 40% 98%;
-    --muted: 217.2 32.6% 17.5%;
-    --muted-foreground: 215 20.2% 65.1%;
+    --muted: 218 30% 12%;
+    --muted-foreground: 216 18% 66%;
     --accent: 217.2 32.6% 17.5%;
     --accent-foreground: 210 40% 98%;
-    --destructive: 0 62.8% 30.6%;
+    --destructive: 0 72% 51%;
     --destructive-foreground: 210 40% 98%;
-    --border: 217.2 32.6% 17.5%;
-    --input: 217.2 32.6% 17.5%;
-    --ring: 212.7 26.8% 83.9%;
+    --border: 217 28% 16%;
+    --input: 217 28% 16%;
+    --ring: 142 71% 45%;
     --radius: 0.5rem;
   }
 }
@@ -32,6 +32,9 @@
     @apply border-border;
   }
   body {
-    @apply bg-background text-foreground;
+    @apply bg-background text-foreground antialiased;
+  }
+  ::selection {
+    @apply bg-primary/30;
   }
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,8 +1,9 @@
 import type { Metadata } from 'next'
-import { Inter } from 'next/font/google'
+import { Inter, Fira_Code } from 'next/font/google'
 import './globals.css'
 
-const inter = Inter({ subsets: ['latin'] })
+const inter = Inter({ subsets: ['latin'], variable: '--font-sans' })
+const firaCode = Fira_Code({ subsets: ['latin'], variable: '--font-mono' })
 
 export const metadata: Metadata = {
   title: 'Code2Flow',
@@ -11,8 +12,8 @@ export const metadata: Metadata = {
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="en" className="dark">
-      <body className={inter.className}>{children}</body>
+    <html lang="en" className={`dark ${inter.variable} ${firaCode.variable}`}>
+      <body className="font-sans">{children}</body>
     </html>
   )
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link'
-import { Zap, Clock, Share2 } from 'lucide-react'
+import { Zap, Clock, Share2, ArrowRight, MoveDown } from 'lucide-react'
 import { createClient } from '@/lib/supabase/server'
 import { Navbar } from '@/components/layout/Navbar'
 import { Button } from '@/components/ui/button'
@@ -23,6 +23,15 @@ const features = [
   },
 ]
 
+const sampleCode = [
+  { code: 'function checkAccess(user) {', indent: 0 },
+  { code: 'if (!user.isActive) {', indent: 1 },
+  { code: 'return deny()', indent: 2 },
+  { code: '}', indent: 1 },
+  { code: 'return grant(user)', indent: 1 },
+  { code: '}', indent: 0 },
+]
+
 export default async function LandingPage() {
   const supabase = createClient()
   const { data: { user } } = await supabase.auth.getUser()
@@ -31,38 +40,96 @@ export default async function LandingPage() {
     <div className="min-h-screen bg-background">
       <DottedSurface />
       <Navbar user={user} />
-      <main className="max-w-4xl mx-auto px-4 py-24 text-center">
-        <h1 className="text-6xl font-bold tracking-tighter mb-6">
+      <main className="relative max-w-5xl mx-auto px-4 pt-20 pb-16 sm:pt-28 text-center">
+        <p className="inline-flex items-center gap-2 font-mono text-xs text-muted-foreground border border-border rounded-full px-3 py-1 mb-6 bg-card/60">
+          <span className="size-1.5 rounded-full bg-primary animate-pulse" aria-hidden />
+          JavaScript · TypeScript · Python
+        </p>
+        <h1 className="text-4xl sm:text-5xl md:text-6xl font-bold tracking-tighter mb-6 text-balance">
           Turn code into flowcharts —{' '}
-          <span className="underline decoration-primary/40 underline-offset-4">instantly</span>
+          <span className="text-primary">instantly</span>
         </h1>
-        <p className="text-xl text-muted-foreground mb-10 max-w-xl mx-auto">
+        <p className="text-lg sm:text-xl text-muted-foreground mb-10 max-w-xl mx-auto text-pretty">
           Paste JavaScript, TypeScript, or Python. Code2Flow generates a live flowchart as you type.
           Save, share, and version your diagrams.
         </p>
-        <div className="flex gap-4 justify-center">
+        <div className="flex flex-col sm:flex-row gap-3 justify-center items-center">
           <Link href={user ? '/editor' : '/register'}>
-            <Button size="lg">Start for free</Button>
+            <Button size="lg" className="gap-2 px-5">
+              Start for free
+              <ArrowRight className="size-4" />
+            </Button>
           </Link>
           {user && (
             <Link href="/dashboard">
-              <Button variant="outline" size="lg">My flowcharts</Button>
+              <Button variant="outline" size="lg" className="px-5">My flowcharts</Button>
             </Link>
           )}
         </div>
-        <div className="mt-20 grid grid-cols-3 gap-8 text-left">
+
+        {/* Code → flowchart illustration */}
+        <div className="mt-16 sm:mt-20 grid md:grid-cols-[1fr_auto_1fr] items-center gap-6 max-w-3xl mx-auto">
+          <div className="text-left rounded-lg border border-border bg-card shadow-xl overflow-hidden">
+            <div className="flex items-center gap-1.5 px-4 h-9 border-b border-border bg-muted/50">
+              <span className="size-2.5 rounded-full bg-destructive/60" aria-hidden />
+              <span className="size-2.5 rounded-full bg-amber-500/60" aria-hidden />
+              <span className="size-2.5 rounded-full bg-primary/60" aria-hidden />
+              <span className="ml-2 font-mono text-xs text-muted-foreground">access.js</span>
+            </div>
+            <pre className="p-4 font-mono text-xs sm:text-sm text-muted-foreground leading-6 overflow-x-auto">
+              {sampleCode.map((l, i) => (
+                <div key={i}>
+                  <span className="select-none text-muted-foreground/40 mr-4">{i + 1}</span>
+                  <span style={{ paddingLeft: `${l.indent}rem` }} className="inline-block">
+                    {l.code}
+                  </span>
+                </div>
+              ))}
+            </pre>
+          </div>
+          <div className="justify-self-center text-primary" aria-hidden>
+            <ArrowRight className="size-6 hidden md:block" />
+            <MoveDown className="size-6 md:hidden" />
+          </div>
+          <div className="flex flex-col items-center gap-1.5 font-mono text-xs" aria-hidden>
+            <div className="px-4 py-2 rounded-full border border-border bg-card">checkAccess(user)</div>
+            <div className="w-px h-3 bg-border" />
+            <div className="px-4 py-2 rounded-md border border-primary/50 bg-primary/10 text-primary">
+              !user.isActive?
+            </div>
+            <div className="flex gap-6 items-start">
+              <div className="flex flex-col items-center gap-1.5">
+                <span className="text-muted-foreground">yes</span>
+                <div className="px-3 py-2 rounded-md border border-destructive/40 bg-destructive/10">deny()</div>
+              </div>
+              <div className="flex flex-col items-center gap-1.5">
+                <span className="text-muted-foreground">no</span>
+                <div className="px-3 py-2 rounded-md border border-border bg-card">grant(user)</div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div className="mt-16 sm:mt-20 grid grid-cols-1 sm:grid-cols-3 gap-4 sm:gap-6 text-left">
           {features.map(f => (
             <div
               key={f.title}
-              className="p-6 bg-muted/40 hover:bg-muted/60 transition-colors duration-150 ring-1 ring-border/50 rounded-lg"
+              className="p-6 bg-card/70 hover:bg-card transition-colors duration-200 ring-1 ring-border/60 hover:ring-border rounded-lg"
             >
-              <f.icon className="size-4 text-muted-foreground mb-3" />
+              <div className="inline-flex items-center justify-center size-9 rounded-md bg-primary/10 text-primary mb-4">
+                <f.icon className="size-4" />
+              </div>
               <h3 className="font-semibold mb-2">{f.title}</h3>
-              <p className="text-sm text-muted-foreground">{f.desc}</p>
+              <p className="text-sm text-muted-foreground leading-relaxed">{f.desc}</p>
             </div>
           ))}
         </div>
       </main>
+      <footer className="relative border-t border-border/60 py-8 text-center">
+        <p className="font-mono text-xs text-muted-foreground">
+          Code2Flow — visualize code as flowcharts
+        </p>
+      </footer>
     </div>
   )
 }

--- a/components/dashboard/FlowchartCard.tsx
+++ b/components/dashboard/FlowchartCard.tsx
@@ -61,7 +61,7 @@ export function FlowchartCard({ flowchart }: { flowchart: Flowchart }) {
   return (
     <Link
       href={`/editor/${flowchart.id}`}
-      className={`group block border border-t-2 ${accentClass} border-border rounded-lg bg-card shadow-sm hover:shadow-md hover:border-primary/50 transition-all duration-150`}
+      className={`group block border border-t-2 ${accentClass} border-border rounded-lg bg-card shadow-sm hover:shadow-lg hover:border-primary/40 hover:-translate-y-0.5 transition-all duration-200 motion-reduce:transition-none motion-reduce:hover:translate-y-0`}
     >
       <div className="p-4">
         <div className="flex items-start justify-between gap-2 mb-3">
@@ -100,7 +100,7 @@ export function FlowchartCard({ flowchart }: { flowchart: Flowchart }) {
             </div>
           </div>
         </div>
-        <p className="text-xs text-muted-foreground">{timeAgo(flowchart.updated_at)}</p>
+        <p className="font-mono text-xs text-muted-foreground">{timeAgo(flowchart.updated_at)}</p>
       </div>
     </Link>
   )

--- a/components/layout/Navbar.tsx
+++ b/components/layout/Navbar.tsx
@@ -1,6 +1,7 @@
 'use client'
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
+import { Workflow } from 'lucide-react'
 import { createClient } from '@/lib/supabase/client'
 import { Button } from '@/components/ui/button'
 
@@ -17,7 +18,12 @@ export function Navbar({ user }: { user: { email?: string } | null }) {
   return (
     <nav className="border-b border-border bg-background/95 backdrop-blur sticky top-0 z-50">
       <div className="max-w-7xl mx-auto px-4 h-14 flex items-center justify-between">
-        <Link href="/" className="font-semibold text-lg tracking-tight">Code2Flow</Link>
+        <Link href="/" className="flex items-center gap-2 font-semibold text-lg tracking-tight hover:opacity-80 transition-opacity duration-150">
+          <span className="inline-flex items-center justify-center size-7 rounded-md bg-primary/15 text-primary">
+            <Workflow className="size-4" />
+          </span>
+          Code2Flow
+        </Link>
         <div className="flex items-center gap-3">
           {user ? (
             <>

--- a/components/ui/DottedSurface.tsx
+++ b/components/ui/DottedSurface.tsx
@@ -67,7 +67,7 @@ export function DottedSurface({ className, ...props }: DottedSurfaceProps) {
             size: 8,
             vertexColors: true,
             transparent: true,
-            opacity: 0.8,
+            opacity: 0.45,
             sizeAttenuation: true,
         });
 
@@ -105,7 +105,12 @@ export function DottedSurface({ className, ...props }: DottedSurfaceProps) {
         };
 
         window.addEventListener('resize', handleResize);
-        animate();
+        const reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+        if (reducedMotion) {
+            renderer.render(scene, camera);
+        } else {
+            animate();
+        }
 
         sceneRef.current = { scene, camera, renderer, particles: [points], animationId, count };
 

--- a/docs/superpowers/plans/2026-07-10-parser-accuracy-part1-js.md
+++ b/docs/superpowers/plans/2026-07-10-parser-accuracy-part1-js.md
@@ -1,0 +1,549 @@
+# Parser Accuracy Part 1 (JavaScript/TypeScript) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix the 5 confirmed JS/TS conversion-accuracy defects (spec: `docs/superpowers/specs/2026-07-10-parser-accuracy-design.md` fixes 1–5).
+
+**Architecture:** All changes stay inside the existing pipeline: acorn AST → recursive `process*` handlers building a `FlowchartGraph` → Mermaid. We extract a shared `processFunctionBody` helper, add class/labeled-statement handlers, and extend `TraversalContext` with labeled-break targets and a throw target.
+
+**Tech Stack:** TypeScript, acorn, jest (`npx jest`). Tests import via the `@/lib/parser` alias.
+
+## Global Constraints
+
+- No new dependencies.
+- Only touch: `lib/parser/javascript.ts`, `lib/parser/types.ts`, new test file `__tests__/parser-js-accuracy.test.ts`.
+- Existing tests in `__tests__/parser.test.ts` must keep passing (`npx jest`).
+- Mermaid labels are escaped by `converter.ts` (`>` → `&gt;`, `"` → `'`) — test expectations must use the escaped form.
+- Commit messages: conventional style, **no Co-Authored-By trailer**.
+
+---
+
+### Task 1: `processFunctionBody` helper + arrow/function-expression bodies (fix 1)
+
+**Files:**
+- Modify: `lib/parser/javascript.ts` (`processFunction` ~line 90, `processVariable` ~line 280, `processExpression` ~line 289)
+- Test: `__tests__/parser-js-accuracy.test.ts` (create)
+
+**Interfaces:**
+- Consumes: existing `processBlock`, `formatExpression`, `TraversalContext`.
+- Produces: `function processFunctionBody(label: string, endLabel: string, bodyStatements: any[], ctx: TraversalContext): BlockResult` and `function isBlockFunction(n: any): boolean` — Task 2 calls both.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `__tests__/parser-js-accuracy.test.ts`:
+
+```ts
+import { codeToMermaid } from '@/lib/parser'
+
+describe('fix 1: function-valued expressions render their bodies', () => {
+  test('arrow function assigned to const', () => {
+    const out = codeToMermaid('const add = (a, b) => {\n  if (a > b) return a\n  return b\n}', 'javascript')
+    expect(out).toContain('(["const add = (a, b) =&gt;"])')
+    expect(out).toContain('a &gt; b?')
+    expect(out).toContain('(["end add"])')
+  })
+
+  test('function expression assigned to a property', () => {
+    const out = codeToMermaid('obj.handler = function (e) {\n  if (e) log(e)\n}', 'javascript')
+    expect(out).toContain('(["obj.handler = function(e)"])')
+    expect(out).toContain('{"e?"}')
+  })
+
+  test('expression-bodied arrow stays a single process node', () => {
+    const out = codeToMermaid('const double = x => x * 2', 'javascript')
+    expect(out).not.toContain('end double')
+  })
+
+  test('mixed declaration keeps plain declarators and expands the function one', () => {
+    const out = codeToMermaid('const limit = 5, check = (x) => {\n  return x < limit\n}', 'javascript')
+    expect(out).toContain('["const limit = 5"]')
+    expect(out).toContain('(["const check = (x) =&gt;"])')
+  })
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx jest __tests__/parser-js-accuracy.test.ts`
+Expected: 4 failures — output currently contains one opaque `const add = () =&gt; {...}` box, no `end add`.
+
+- [ ] **Step 3: Implement**
+
+In `lib/parser/javascript.ts`, replace `processFunction` with the helper + thin wrapper:
+
+```ts
+function processFunctionBody(label: string, endLabel: string, bodyStatements: any[], ctx: TraversalContext): BlockResult {
+  const funcNode = ctx.graph.createNode('subroutine', label, 'rounded')
+  const endNode  = ctx.graph.createNode('process', endLabel, 'rounded')
+  const fCtx = ctx.clone()
+  fCtx.currentNode = funcNode
+  fCtx.returnTarget = endNode
+  // function boundary: enclosing loop targets don't apply inside the body
+  fCtx.breakTarget = null
+  fCtx.continueTarget = null
+  const body = processBlock(bodyStatements, fCtx)
+  if (body.entry) ctx.graph.connect(funcNode, body.entry)
+  if (body.exit)  ctx.graph.connect(body.exit, endNode)
+  return { entry: funcNode, exit: endNode }
+}
+
+function isBlockFunction(n: any): boolean {
+  return !!n && (n.type === 'ArrowFunctionExpression' || n.type === 'FunctionExpression') && n.body?.type === 'BlockStatement'
+}
+
+function functionLabel(prefix: string, fn: any): string {
+  const params = fn.params.map((p: any) => formatExpression(p)).join(', ')
+  return fn.type === 'ArrowFunctionExpression' ? `${prefix} = (${params}) =>` : `${prefix} = function(${params})`
+}
+
+function processFunction(node: any, ctx: TraversalContext): BlockResult {
+  const name = node.id?.name ?? 'anonymous'
+  const params = node.params.map((p: any) => formatExpression(p)).join(', ')
+  return processFunctionBody(`function ${name}(${params})`, `end ${name}`, node.body.body, ctx)
+}
+```
+
+Replace `processVariable`:
+
+```ts
+function processVariable(node: any, ctx: TraversalContext): BlockResult {
+  if (!node.declarations.some((d: any) => isBlockFunction(d.init))) {
+    const decls = node.declarations.map((d: any) => {
+      const name = formatExpression(d.id)
+      return d.init ? `${name} = ${formatExpression(d.init)}` : name
+    }).join(', ')
+    const n = ctx.graph.createNode('process', `${node.kind} ${decls}`, 'rectangle')
+    return { entry: n, exit: n }
+  }
+  // At least one declarator holds a function with a block body: render each
+  // declarator separately so the function's control flow stays visible.
+  let first: FlowchartNode | null = null
+  let prev: FlowchartNode | null = null
+  for (const d of node.declarations) {
+    const name = formatExpression(d.id)
+    let r: BlockResult
+    if (isBlockFunction(d.init)) {
+      r = processFunctionBody(functionLabel(`${node.kind} ${name}`, d.init), `end ${name}`, d.init.body.body, ctx)
+    } else {
+      const label = d.init ? `${node.kind} ${name} = ${formatExpression(d.init)}` : `${node.kind} ${name}`
+      const n = ctx.graph.createNode('process', label, 'rectangle')
+      r = { entry: n, exit: n }
+    }
+    if (!first) first = r.entry
+    if (prev && r.entry) ctx.graph.connect(prev, r.entry)
+    prev = r.exit
+  }
+  return { entry: first, exit: prev }
+}
+```
+
+Replace `processExpression`:
+
+```ts
+function processExpression(node: any, ctx: TraversalContext): BlockResult {
+  const expr = node.expression
+  if (expr.type === 'AssignmentExpression' && expr.operator === '=' && isBlockFunction(expr.right)) {
+    const target = formatExpression(expr.left)
+    return processFunctionBody(functionLabel(target, expr.right), `end ${target}`, expr.right.body.body, ctx)
+  }
+  const n = ctx.graph.createNode('process', formatExpression(expr), 'rectangle')
+  return { entry: n, exit: n }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx jest __tests__/parser-js-accuracy.test.ts __tests__/parser.test.ts`
+Expected: all PASS (existing suite included).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/parser/javascript.ts __tests__/parser-js-accuracy.test.ts
+git commit -m "fix(parser): render arrow/function-expression bodies as subroutines"
+```
+
+---
+
+### Task 2: Class declarations render members (fix 2)
+
+**Files:**
+- Modify: `lib/parser/javascript.ts` (`processStatement` switch ~line 54, `formatExpression` ~line 11, `parseJS` ~line 39)
+- Test: `__tests__/parser-js-accuracy.test.ts`
+
+**Interfaces:**
+- Consumes: `processFunctionBody`, `isBlockFunction`, `functionLabel` from Task 1.
+- Produces: `function processClassJS(node: any, ctx: TraversalContext): BlockResult`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `__tests__/parser-js-accuracy.test.ts`:
+
+```ts
+describe('fix 2: classes render members', () => {
+  test('class with methods renders subroutine + method bodies', () => {
+    const code = 'class Stack extends Base {\n  constructor() { super(); this.items = [] }\n  pop() {\n    if (this.items.length === 0) return null\n    return this.items.pop()\n  }\n}'
+    const out = codeToMermaid(code, 'javascript')
+    expect(out).toContain('class Stack extends Base')
+    expect(out).toContain('(["constructor()"])')
+    expect(out).toContain('(["pop()"])')
+    expect(out).toContain('this.items.length === 0?')
+    expect(out).not.toContain('ClassDeclaration')
+  })
+
+  test('class field renders as a process node', () => {
+    const out = codeToMermaid('class A {\n  count = 0\n  reset() { this.count = 0 }\n}', 'javascript')
+    expect(out).toContain('["count = 0"]')
+    expect(out).toContain('(["reset()"])')
+  })
+
+  test('class expression assigned to const', () => {
+    const out = codeToMermaid('const A = class {\n  go() { run() }\n}', 'javascript')
+    expect(out).toContain('class A')
+    expect(out).toContain('(["go()"])')
+  })
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx jest __tests__/parser-js-accuracy.test.ts -t "fix 2"`
+Expected: FAIL — first test shows `ClassDeclaration` box; second may fail at parse (class fields need ecmaVersion > 2020).
+
+- [ ] **Step 3: Implement**
+
+In `parseJS`, change `ecmaVersion: 2020` → `ecmaVersion: 'latest'` (class fields are ES2022).
+
+In `formatExpression`, add a case (anywhere in the switch): `case 'Super': text = 'super'; break`.
+
+Add handler + switch cases:
+
+```ts
+function processClassJS(node: any, ctx: TraversalContext): BlockResult {
+  const name = node.id?.name ?? 'anonymous'
+  const base = node.superClass ? ` extends ${formatExpression(node.superClass)}` : ''
+  const cls  = ctx.graph.createNode('subroutine', `class ${name}${base}`, 'rounded')
+  let prev: FlowchartNode = cls
+  for (const m of node.body.body) {
+    let r: BlockResult | null = null
+    if (m.type === 'MethodDefinition' && m.value?.body) {
+      const key = formatExpression(m.key)
+      const params = m.value.params.map((p: any) => formatExpression(p)).join(', ')
+      let label = `${key}(${params})`
+      if (m.kind === 'get') label = `get ${label}`
+      if (m.kind === 'set') label = `set ${label}`
+      if (m.static) label = `static ${label}`
+      r = processFunctionBody(label, `end ${key}`, m.value.body.body, ctx)
+    } else if (m.type === 'PropertyDefinition') {
+      const key = formatExpression(m.key)
+      if (isBlockFunction(m.value)) {
+        r = processFunctionBody(functionLabel(key, m.value), `end ${key}`, m.value.body.body, ctx)
+      } else {
+        const n = ctx.graph.createNode('process', m.value ? `${key} = ${formatExpression(m.value)}` : key, 'rectangle')
+        r = { entry: n, exit: n }
+      }
+    }
+    if (r?.entry) { ctx.graph.connect(prev, r.entry); prev = r.exit ?? prev }
+  }
+  return { entry: cls, exit: prev }
+}
+```
+
+In `processStatement`, add before `default`: `case 'ClassDeclaration': return processClassJS(node, ctx)`.
+
+In Task 1's `processVariable` function-path loop, extend the special case: change the `some(...)` guard to `node.declarations.some((d: any) => isBlockFunction(d.init) || d.init?.type === 'ClassExpression')` and inside the loop add before the `isBlockFunction` branch:
+
+```ts
+if (d.init?.type === 'ClassExpression') {
+  r = processClassJS({ ...d.init, id: d.init.id ?? d.id }, ctx)
+} else if (isBlockFunction(d.init)) { ...existing... }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx jest __tests__/parser-js-accuracy.test.ts __tests__/parser.test.ts`
+Expected: all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/parser/javascript.ts __tests__/parser-js-accuracy.test.ts
+git commit -m "fix(parser): render class members instead of opaque ClassDeclaration box"
+```
+
+---
+
+### Task 3: Switch without default gets a no-match edge (fix 3)
+
+**Files:**
+- Modify: `lib/parser/javascript.ts` (`processSwitch` ~line 200)
+- Test: `__tests__/parser-js-accuracy.test.ts`
+
+**Interfaces:** none new.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+describe('fix 3: switch no-match edge', () => {
+  test('switch without default connects decision to merge', () => {
+    const out = codeToMermaid('switch (x) {\n  case 1:\n    a()\n    break\n}\ndone()', 'javascript')
+    expect(out).toContain('-->|no match|')
+  })
+
+  test('switch with default gets no extra edge', () => {
+    const out = codeToMermaid('switch (x) {\n  case 1:\n    a()\n    break\n  default:\n    d()\n}', 'javascript')
+    expect(out).not.toContain('no match')
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx jest __tests__/parser-js-accuracy.test.ts -t "fix 3"`
+Expected: first test FAILs (no `no match` edge exists today).
+
+- [ ] **Step 3: Implement**
+
+In `processSwitch`, before `return { entry: sw, exit: after }`:
+
+```ts
+if (!node.cases.some((c: any) => !c.test)) ctx.graph.connect(sw, after, 'no match')
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx jest __tests__/parser-js-accuracy.test.ts __tests__/parser.test.ts`
+Expected: all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/parser/javascript.ts __tests__/parser-js-accuracy.test.ts
+git commit -m "fix(parser): add no-match exit edge for switch without default"
+```
+
+---
+
+### Task 4: Labeled statements + labeled break/continue (fix 4)
+
+**Files:**
+- Modify: `lib/parser/types.ts` (`TraversalContext` ~line 56)
+- Modify: `lib/parser/javascript.ts` (`processStatement`, `processFor`, `processWhile`, `processDoWhile`, `processForIn`, `processSwitch`, `processBreak`, `processContinue`)
+- Test: `__tests__/parser-js-accuracy.test.ts`
+
+**Interfaces:**
+- Produces on `TraversalContext`: `labeledTargets: Record<string, { break: FlowchartNode | null; continue: FlowchartNode | null }>` and `pendingLabel: string | null` (both copied by `clone()`).
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+describe('fix 4: labeled statements', () => {
+  test('labeled loop renders and break outer exits the outer loop', () => {
+    const code = 'outer: for (const a of xs) {\n  for (const b of ys) {\n    if (a === b) break outer\n  }\n}\ndone()'
+    const out = codeToMermaid(code, 'javascript')
+    expect(out).not.toContain('"Labeled"')
+    expect(out).toContain('a of xs?')
+    const breakId = out.match(/(N\d+)\["break outer"\]/)?.[1]
+    const doneId  = out.match(/(N\d+)\["done\(\)"\]/)?.[1]
+    expect(breakId).toBeTruthy()
+    expect(doneId).toBeTruthy()
+    // the node break jumps to must be the outer loop's merge — the one that leads to done()
+    const outerMerge = out.match(new RegExp(`(N\\d+) --> ${doneId}\\b`))?.[1]
+    expect(out).toContain(`${breakId} --> ${outerMerge}`)
+  })
+
+  test('labeled continue targets the labeled loop condition', () => {
+    const code = 'outer: while (a) {\n  while (b) {\n    continue outer\n  }\n}'
+    const out = codeToMermaid(code, 'javascript')
+    const contId = out.match(/(N\d+)\["continue outer"\]/)?.[1]
+    const outerCond = out.match(/(N\d+)\{"a\?"\}/)?.[1]
+    expect(out).toContain(`${contId} --> ${outerCond}`)
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx jest __tests__/parser-js-accuracy.test.ts -t "fix 4"`
+Expected: FAIL — output contains a single node labeled `Labeled`.
+
+- [ ] **Step 3: Implement**
+
+`lib/parser/types.ts` — add to `TraversalContext`:
+
+```ts
+labeledTargets: Record<string, { break: FlowchartNode | null; continue: FlowchartNode | null }> = {}
+pendingLabel: string | null = null
+```
+
+and in `clone()` add:
+
+```ts
+ctx.labeledTargets = { ...this.labeledTargets }
+ctx.pendingLabel = this.pendingLabel
+```
+
+`lib/parser/javascript.ts` — in `processStatement`, add before `default`:
+
+```ts
+case 'LabeledStatement': {
+  const lCtx = ctx.clone()
+  lCtx.pendingLabel = node.label.name
+  return processStatement(node.body, lCtx)
+}
+```
+
+Add this registration line to each loop handler, immediately **before** the body context is cloned (the `ctx.clone()` call for `loopCtx`/`lCtx`), so the body context inherits the entry. The `continue` value differs per handler:
+
+- `processFor` (before `const loopCtx = ctx.clone()`):
+  `if (ctx.pendingLabel) { ctx.labeledTargets[ctx.pendingLabel] = { break: after, continue: update ?? cond }; ctx.pendingLabel = null }`
+- `processWhile` (before `const lCtx = ctx.clone()`):
+  `if (ctx.pendingLabel) { ctx.labeledTargets[ctx.pendingLabel] = { break: after, continue: cond }; ctx.pendingLabel = null }`
+- `processDoWhile` (before `const lCtx = ctx.clone()`):
+  `if (ctx.pendingLabel) { ctx.labeledTargets[ctx.pendingLabel] = { break: after, continue: cond }; ctx.pendingLabel = null }`
+- `processForIn` (before `const lCtx = ctx.clone()`):
+  `if (ctx.pendingLabel) { ctx.labeledTargets[ctx.pendingLabel] = { break: after, continue: cond }; ctx.pendingLabel = null }`
+- `processSwitch` (before the `for (const c of node.cases)` loop):
+  `if (ctx.pendingLabel) { ctx.labeledTargets[ctx.pendingLabel] = { break: after, continue: null }; ctx.pendingLabel = null }`
+
+Replace `processBreak` and `processContinue`:
+
+```ts
+function processBreak(node: any, ctx: TraversalContext): BlockResult {
+  const n = ctx.graph.createNode('process', node.label ? `break ${node.label.name}` : 'break', 'rectangle')
+  const target = node.label ? ctx.labeledTargets[node.label.name]?.break ?? ctx.breakTarget : ctx.breakTarget
+  if (target) ctx.graph.connect(n, target)
+  return { entry: n, exit: null }
+}
+
+function processContinue(node: any, ctx: TraversalContext): BlockResult {
+  const n = ctx.graph.createNode('process', node.label ? `continue ${node.label.name}` : 'continue', 'rectangle')
+  const target = node.label ? ctx.labeledTargets[node.label.name]?.continue ?? ctx.continueTarget : ctx.continueTarget
+  if (target) ctx.graph.connect(n, target)
+  return { entry: n, exit: null }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx jest __tests__/parser-js-accuracy.test.ts __tests__/parser.test.ts`
+Expected: all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/parser/types.ts lib/parser/javascript.ts __tests__/parser-js-accuracy.test.ts
+git commit -m "fix(parser): support labeled statements and labeled break/continue"
+```
+
+---
+
+### Task 5: `throw` routes to the enclosing catch (fix 5, JS half)
+
+**Files:**
+- Modify: `lib/parser/types.ts` (`TraversalContext`)
+- Modify: `lib/parser/javascript.ts` (`processTry` ~line 223, `processThrow` ~line 275, `processFunctionBody` from Task 1)
+- Test: `__tests__/parser-js-accuracy.test.ts`
+
+**Interfaces:**
+- Produces on `TraversalContext`: `throwTarget: FlowchartNode | null` (copied by `clone()`) — Part 2's Python raise-routing task consumes this.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+describe('fix 5: throw routes to catch', () => {
+  test('throw inside try connects to the catch node', () => {
+    const code = "try {\n  if (bad) throw new Error('x')\n  ok()\n} catch (e) {\n  handle(e)\n}"
+    const out = codeToMermaid(code, 'javascript')
+    const throwId = out.match(/(N\d+)\["throw new Error\('x'\)"\]/)?.[1]
+    const catchId = out.match(/(N\d+)\(\["catch \(e\)"\]\)/)?.[1]
+    expect(throwId).toBeTruthy()
+    expect(catchId).toBeTruthy()
+    expect(out).toContain(`${throwId} --> ${catchId}`)
+  })
+
+  test('throw with no enclosing try stays terminal', () => {
+    const out = codeToMermaid("throw new Error('boom')", 'javascript')
+    const throwId = out.match(/(N\d+)\["throw new Error\('boom'\)"\]/)?.[1]
+    expect(out).not.toMatch(new RegExp(`${throwId} --> `))
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx jest __tests__/parser-js-accuracy.test.ts -t "fix 5"`
+Expected: first test FAILs (throw node has no outgoing edge).
+
+- [ ] **Step 3: Implement**
+
+`lib/parser/types.ts` — add to `TraversalContext`: `throwTarget: FlowchartNode | null = null`, and in `clone()`: `ctx.throwTarget = this.throwTarget`.
+
+`lib/parser/javascript.ts` — in `processFunctionBody`, next to the break/continue resets add `fCtx.throwTarget = null` (a function's throw fires at call time, not where it's defined).
+
+Replace `processTry` — the catch/finally nodes are now created **before** the try body is walked so the body's context can point at them:
+
+```ts
+function processTry(node: any, ctx: TraversalContext): BlockResult {
+  const tryNode = ctx.graph.createNode('process', 'try', 'rounded')
+  const after   = ctx.graph.createNode('merge' as any, '', 'circle')
+
+  let catchNode: FlowchartNode | null = null
+  if (node.handler) {
+    const param = node.handler.param ? formatExpression(node.handler.param) : 'error'
+    catchNode = ctx.graph.createNode('process', `catch (${param})`, 'rounded')
+    ctx.graph.connect(tryNode, catchNode, 'error')
+  }
+  const finallyNode: FlowchartNode | null = node.finalizer
+    ? ctx.graph.createNode('process', 'finally', 'rounded')
+    : null
+
+  const tCtx = ctx.clone(); tCtx.currentNode = tryNode
+  tCtx.throwTarget = catchNode ?? finallyNode
+  const tryRes = processBlock(node.block.body, tCtx)
+  if (tryRes.entry) ctx.graph.connect(tryNode, tryRes.entry)
+
+  if (finallyNode) {
+    const fCtx = ctx.clone(); fCtx.currentNode = finallyNode
+    const fRes = processBlock(node.finalizer.body, fCtx)
+    if (fRes.entry) ctx.graph.connect(finallyNode, fRes.entry)
+    ctx.graph.connect(fRes.exit ?? finallyNode, after)
+  }
+
+  const target = finallyNode ?? after
+  if (tryRes.exit) ctx.graph.connect(tryRes.exit, target)
+
+  if (catchNode) {
+    const cCtx = ctx.clone(); cCtx.currentNode = catchNode
+    const cRes = processBlock(node.handler.body.body, cCtx)
+    if (cRes.entry) ctx.graph.connect(catchNode, cRes.entry)
+    ctx.graph.connect(cRes.exit ?? catchNode, target)
+  }
+
+  return { entry: tryNode, exit: after }
+}
+```
+
+(Note: the catch body's context clones from the **outer** ctx, so a throw inside catch correctly propagates outward, not back into the same catch.)
+
+Replace `processThrow`:
+
+```ts
+function processThrow(node: any, ctx: TraversalContext): BlockResult {
+  const n = ctx.graph.createNode('process', `throw ${formatExpression(node.argument)}`, 'rectangle')
+  if (ctx.throwTarget) ctx.graph.connect(n, ctx.throwTarget)
+  return { entry: n, exit: null }
+}
+```
+
+- [ ] **Step 4: Run the full suite**
+
+Run: `npx jest`
+Expected: all suites PASS (node-creation order inside try changed; existing tests assert labels, not ids).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/parser/types.ts lib/parser/javascript.ts __tests__/parser-js-accuracy.test.ts
+git commit -m "fix(parser): route throw statements to the enclosing catch"
+```

--- a/docs/superpowers/plans/2026-07-10-parser-accuracy-part2-python.md
+++ b/docs/superpowers/plans/2026-07-10-parser-accuracy-part2-python.md
@@ -1,0 +1,694 @@
+# Parser Accuracy Part 2 (Python) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix the 5 confirmed Python conversion-accuracy defects plus the Python half of throw-routing (spec: `docs/superpowers/specs/2026-07-10-parser-accuracy-design.md` fixes 5–10).
+
+**Architecture:** Add a logical-line scanner (`python-lines.ts`) that joins bracket/backslash/triple-quote continuations and strips comments; restructure `parsePython` to split inline suites at the top-level colon and to attach `else`/`elif` to the **last** statement of the parent block; rework `processTry` for `try/else` and raise-routing.
+
+**Tech Stack:** TypeScript, jest (`npx jest`). Tests import via `@/lib/parser`.
+
+## Global Constraints
+
+- **Requires Part 1 complete** — `TraversalContext.throwTarget` (added in Part 1 Task 5) is consumed here.
+- No new dependencies.
+- Only touch: `lib/parser/python.ts`, new `lib/parser/python-lines.ts`, new test files `__tests__/python-lines.test.ts`, `__tests__/parser-python-accuracy.test.ts`.
+- `convertPython` must never throw: the scanner is total — unclosed brackets/strings at EOF flush the pending logical line as-is.
+- Existing tests must keep passing (`npx jest`).
+- Mermaid labels are escaped by `converter.ts` (`>` → `&gt;`, `"` → `'`) — test expectations must use the escaped form.
+- Commit messages: conventional style, **no Co-Authored-By trailer**.
+
+---
+
+### Task 1: Logical-line scanner (fix 7)
+
+**Files:**
+- Create: `lib/parser/python-lines.ts`
+- Modify: `lib/parser/python.ts` (delete its local `getIndent`, import from `./python-lines`; rewrite `parsePython`'s line loop)
+- Test: `__tests__/python-lines.test.ts` (create), `__tests__/parser-python-accuracy.test.ts` (create)
+
+**Interfaces:**
+- Produces (all exported from `lib/parser/python-lines.ts`; Tasks 2+ consume them):
+  - `interface LogicalLine { text: string; indent: number; lineNum: number }`
+  - `toLogicalLines(code: string): LogicalLine[]`
+  - `topLevelIndexOf(text: string, target: string, from?: number): number`
+  - `splitTopLevel(text: string, sep: string): string[]`
+  - `getIndent(line: string): number` (moved verbatim from python.ts)
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `__tests__/python-lines.test.ts`:
+
+```ts
+import { toLogicalLines, topLevelIndexOf, splitTopLevel } from '@/lib/parser/python-lines'
+
+describe('toLogicalLines', () => {
+  test('joins bracket continuations into one logical line', () => {
+    const out = toLogicalLines('result = compute(\n    alpha,\n    beta,\n)\nprint(result)')
+    expect(out.map(l => l.text)).toEqual(['result = compute( alpha, beta, )', 'print(result)'])
+    expect(out[0].indent).toBe(0)
+    expect(out[0].lineNum).toBe(1)
+  })
+
+  test('joins backslash continuations', () => {
+    const out = toLogicalLines('total = a + \\\n    b')
+    expect(out.map(l => l.text)).toEqual(['total = a + b'])
+  })
+
+  test('strips comments outside strings only', () => {
+    const out = toLogicalLines('x = "a # b"  # real comment\n# full-line comment\ny = 1')
+    expect(out.map(l => l.text)).toEqual(['x = "a # b"', 'y = 1'])
+  })
+
+  test('brackets inside strings do not open continuations', () => {
+    const out = toLogicalLines('msg = "if you see this: fine ("\nprint(msg)')
+    expect(out).toHaveLength(2)
+  })
+
+  test('triple-quoted string spanning lines stays one logical line', () => {
+    const out = toLogicalLines('doc = """line one\nline two"""\nprint(doc)')
+    expect(out).toHaveLength(2)
+    expect(out[0].text).toContain('line two')
+  })
+
+  test('unclosed bracket at EOF still flushes', () => {
+    const out = toLogicalLines('x = f(\n    1,')
+    expect(out).toHaveLength(1)
+  })
+})
+
+describe('topLevelIndexOf / splitTopLevel', () => {
+  test('skips colons inside brackets and strings', () => {
+    expect(topLevelIndexOf('if d[1:2] and "a:b": pass', ':')).toBe(19)
+    expect(topLevelIndexOf('x = 1', ':')).toBe(-1)
+  })
+
+  test('splits on top-level separators only', () => {
+    expect(splitTopLevel('a(); b("x;y"); c()', ';')).toEqual(['a()', ' b("x;y")', ' c()'])
+  })
+})
+```
+
+Create `__tests__/parser-python-accuracy.test.ts`:
+
+```ts
+import { codeToMermaid } from '@/lib/parser'
+
+describe('fix 7: multi-line statements', () => {
+  test('call split across lines renders as one node', () => {
+    const out = codeToMermaid('result = compute(\n    alpha,\n    beta,\n)\nprint(result)', 'python')
+    expect(out).toContain('result = compute( alpha, beta, )')
+    expect(out).not.toContain('["alpha,"]')
+  })
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx jest __tests__/python-lines.test.ts __tests__/parser-python-accuracy.test.ts`
+Expected: python-lines suite fails at import (module doesn't exist); accuracy test fails with four separate boxes.
+
+- [ ] **Step 3: Implement the scanner**
+
+Create `lib/parser/python-lines.ts`:
+
+```ts
+export interface LogicalLine { text: string; indent: number; lineNum: number }
+
+export function getIndent(line: string): number {
+  let n = 0
+  for (const c of line) { if (c === ' ') n++; else if (c === '\t') n += 4; else break }
+  return n
+}
+
+/**
+ * Joins physical lines into logical lines: open brackets, trailing-backslash
+ * continuations, and triple-quoted strings all continue onto the next line.
+ * Comments are stripped only outside strings. Total: unclosed state at EOF
+ * flushes the pending logical line instead of erroring.
+ */
+export function toLogicalLines(code: string): LogicalLine[] {
+  const physical = code.split('\n')
+  const out: LogicalLine[] = []
+  let buf: string[] = []
+  let indent = 0
+  let lineNum = 0
+  let depth = 0
+  let str: string | null = null // open string delimiter: ', ", ''' or """
+
+  const flush = () => {
+    const text = buf.join(' ').trim()
+    if (text) out.push({ text, indent, lineNum })
+    buf = []
+  }
+
+  for (let i = 0; i < physical.length; i++) {
+    const raw = physical[i]
+    if (buf.length === 0 && str === null) {
+      if (!raw.trim() || raw.trim().startsWith('#')) continue
+      indent = getIndent(raw)
+      lineNum = i + 1
+    }
+
+    let piece = ''
+    for (let j = 0; j < raw.length; j++) {
+      const c = raw[j]
+      if (str !== null) {
+        piece += c
+        if (str.length === 3) {
+          if (raw.startsWith(str, j)) { piece += str.slice(1); j += 2; str = null }
+        } else if (c === '\\') { piece += raw[j + 1] ?? ''; j++ }
+        else if (c === str) str = null
+        continue
+      }
+      if (c === '#') break
+      if (c === "'" || c === '"') {
+        if (raw.startsWith(c.repeat(3), j)) { str = c.repeat(3); piece += str; j += 2 }
+        else { str = c; piece += c }
+        continue
+      }
+      if ('([{'.includes(c)) depth++
+      else if (')]}'.includes(c)) depth = Math.max(0, depth - 1)
+      piece += c
+    }
+
+    // a single-quoted string cannot span physical lines — recover
+    if (str !== null && str.length === 1) str = null
+
+    const continued = piece.trimEnd().endsWith('\\')
+    buf.push((continued ? piece.trimEnd().slice(0, -1) : piece).trim())
+
+    if (depth === 0 && str === null && !continued) flush()
+  }
+  flush()
+  return out
+}
+
+/** Index of the first `target` char at bracket-depth 0 outside strings, at or after `from`. */
+export function topLevelIndexOf(text: string, target: string, from = 0): number {
+  let depth = 0
+  let str: string | null = null
+  for (let j = 0; j < text.length; j++) {
+    const c = text[j]
+    if (str !== null) {
+      if (str.length === 3) { if (text.startsWith(str, j)) { j += 2; str = null } }
+      else if (c === '\\') j++
+      else if (c === str) str = null
+      continue
+    }
+    if (c === "'" || c === '"') { str = text.startsWith(c.repeat(3), j) ? c.repeat(3) : c; if (str.length === 3) j += 2; continue }
+    if ('([{'.includes(c)) depth++
+    else if (')]}'.includes(c)) depth = Math.max(0, depth - 1)
+    else if (c === target && depth === 0 && j >= from) return j
+  }
+  return -1
+}
+
+/** Splits on `sep` occurring at bracket-depth 0 outside strings; drops empty parts. */
+export function splitTopLevel(text: string, sep: string): string[] {
+  const parts: string[] = []
+  let start = 0
+  let idx = topLevelIndexOf(text, sep, 0)
+  while (idx !== -1) {
+    parts.push(text.slice(start, idx))
+    start = idx + 1
+    idx = topLevelIndexOf(text, sep, start)
+  }
+  parts.push(text.slice(start))
+  return parts.filter(p => p.trim())
+}
+```
+
+In `lib/parser/python.ts`: delete the local `getIndent`, add `import { toLogicalLines } from './python-lines'` (Task 2 extends this import with `topLevelIndexOf, splitTopLevel`), and rewrite the loop head of `parsePython` — everything from `const lines = code.split('\n')` through the `const indent = getIndent(raw)` line becomes:
+
+```ts
+export function parsePython(code: string): PyNode {
+  const ast: PyNode = { type: 'Program', body: [] }
+  const stack: Array<{ indent: number; node: PyNode; type: string }> = [{ indent: -1, node: ast, type: 'program' }]
+
+  for (const ll of toLogicalLines(code)) {
+    const trimmed = ll.text
+    const indent = ll.indent
+
+    while (stack.length > 1 && indent <= stack[stack.length - 1].indent) stack.pop()
+    const parent = stack[stack.length - 1]
+    const node = parseLine(trimmed, ll.lineNum)
+    if (!node) continue
+    // ... rest of the loop body unchanged ...
+```
+
+(The rest of the loop — elif/else attach, except/finally attach, case attach, push — is unchanged in this task; `trimmed.endsWith(':')` still gates block-opening.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx jest __tests__/python-lines.test.ts __tests__/parser-python-accuracy.test.ts __tests__/parser.test.ts`
+Expected: all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/parser/python-lines.ts lib/parser/python.ts __tests__/python-lines.test.ts __tests__/parser-python-accuracy.test.ts
+git commit -m "fix(parser): join Python physical lines into logical lines before parsing"
+```
+
+---
+
+### Task 2: Inline suites + last-statement else/elif attachment (fixes 6 + 8 parse half)
+
+**Files:**
+- Modify: `lib/parser/python.ts` (`parsePython`)
+- Test: `__tests__/parser-python-accuracy.test.ts`
+
+**Interfaces:**
+- Consumes: `topLevelIndexOf`, `splitTopLevel` from Task 1.
+- Produces: `Try` PyNodes may now carry `elsebody: PyNode | null` (rendered in Task 3).
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `__tests__/parser-python-accuracy.test.ts`:
+
+```ts
+describe('fix 6: single-line suites', () => {
+  test('inline if body is kept', () => {
+    const out = codeToMermaid('x = 1\nif x > 0: print("positive")\nprint("done")', 'python')
+    expect(out).toContain('x &gt; 0?')
+    expect(out).toContain("print('positive')")
+    expect(out).toContain('-->|Yes|')
+  })
+
+  test('semicolon-separated inline suite renders every statement', () => {
+    const out = codeToMermaid('if flag: a(); b()', 'python')
+    expect(out).toContain('["a()"]')
+    expect(out).toContain('["b()"]')
+  })
+
+  test('colon inside a slice or string does not split the header', () => {
+    const out = codeToMermaid('for x in d[1:5]:\n    print(x)', 'python')
+    expect(out).toContain('x in d[1:5]?')
+    expect(out).toContain('print(x)')
+  })
+})
+
+describe('fix 8 (parse): else attaches to the nearest preceding block', () => {
+  test('else after try does not steal from an earlier if', () => {
+    const code = 'if a:\n    one()\ntry:\n    risky()\nexcept:\n    handle()\nelse:\n    ok()'
+    const out = codeToMermaid(code, 'python')
+    const aCond = out.match(/(N\d+)\{"a\?"\}/)?.[1]
+    const okId  = out.match(/(N\d+)\["ok\(\)"\]/)?.[1]
+    expect(okId).toBeTruthy()
+    // the if's No edge must not lead to ok()
+    expect(out).not.toContain(`${aCond} -->|No| ${okId}`)
+  })
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx jest __tests__/parser-python-accuracy.test.ts -t "fix 6"`
+Expected: FAIL — `print('positive')` missing (inline body dropped). The fix-8 test may pass or fail depending on current misattachment; keep it regardless.
+
+- [ ] **Step 3: Implement**
+
+Rewrite `parsePython` in `lib/parser/python.ts`:
+
+```ts
+const COMPOUND = /^(if|elif|else|for|while|def|class|try|except|finally|with|match|case)\b/
+
+export function parsePython(code: string): PyNode {
+  const ast: PyNode = { type: 'Program', body: [] }
+  const stack: Array<{ indent: number; node: PyNode; type: string }> = [{ indent: -1, node: ast, type: 'program' }]
+
+  for (const ll of toLogicalLines(code)) {
+    const trimmed = ll.text
+    const indent = ll.indent
+
+    while (stack.length > 1 && indent <= stack[stack.length - 1].indent) stack.pop()
+    const parent = stack[stack.length - 1]
+
+    let node: PyNode | null
+    let isBlock = false
+    if (COMPOUND.test(trimmed)) {
+      const ci = topLevelIndexOf(trimmed, ':')
+      if (ci !== -1 && ci < trimmed.length - 1) {
+        // inline suite: `if x: f(); g()` — parse header and remainder separately
+        node = parseLine(trimmed.slice(0, ci + 1), ll.lineNum)
+        const rest = trimmed.slice(ci + 1).trim()
+        if (node && rest) {
+          node.body = splitTopLevel(rest, ';')
+            .map(s => parseLine(s.trim(), ll.lineNum))
+            .filter((n): n is PyNode => !!n)
+        }
+      } else {
+        node = parseLine(trimmed, ll.lineNum)
+        isBlock = ci !== -1 // header with nothing after the colon opens a block
+      }
+    } else {
+      node = parseLine(trimmed, ll.lineNum)
+    }
+    if (!node) continue
+
+    // Attach elif/else to the LAST statement of the parent block only
+    if (node.type === 'Elif' || node.type === 'Else') {
+      const body = parent.node.body ?? []
+      const last = body[body.length - 1]
+      if (last && node.type === 'Elif' && last.type === 'If') {
+        const nested: PyNode = { type: 'If', test: node.test, body: node.body ?? [], orelse: [] }
+        const tail = getLastIf(last)
+        tail.orelse = tail.orelse ?? []
+        tail.orelse.push(nested)
+        if (isBlock) stack.push({ indent, node: nested, type: 'If' })
+        continue
+      }
+      if (last && node.type === 'Else') {
+        if (last.type === 'For' || last.type === 'While') last.orelse = node
+        else if (last.type === 'Try') last.elsebody = node
+        else if (last.type === 'If') { const tail = getLastIf(last); tail._elseNode = node }
+        else { continue } // stray else — drop
+        if (isBlock) stack.push({ indent, node, type: 'Else' })
+        continue
+      }
+      continue // stray elif/else with no preceding block — drop
+    }
+
+    // Attach except/finally to most recent try
+    if (node.type === 'ExceptHandler' || node.type === 'Finally') {
+      const body = parent.node.body ?? []
+      const tryNode = [...body].reverse().find((n: PyNode) => n.type === 'Try')
+      if (tryNode) {
+        if (node.type === 'ExceptHandler') tryNode.handlers.push(node)
+        else tryNode.finalbody = node
+        if (isBlock) stack.push({ indent, node, type: node.type })
+        continue
+      }
+    }
+
+    // Attach case to most recent match
+    if (node.type === 'Case') {
+      const body = parent.node.body ?? []
+      const matchNode = [...body].reverse().find((n: PyNode) => n.type === 'Match')
+      if (matchNode) {
+        matchNode.cases.push(node)
+        if (isBlock) stack.push({ indent, node, type: 'Case' })
+        continue
+      }
+    }
+
+    parent.node.body = parent.node.body ?? []
+    parent.node.body.push(node)
+    if (isBlock) stack.push({ indent, node, type: node.type })
+  }
+
+  return ast
+}
+```
+
+Notes:
+- `COMPOUND` uses `\b`, so `match = 5` or `case_count = 1` fall through to the plain-expression path (`topLevelIndexOf` returns -1 for them anyway).
+- `parseLine` itself is unchanged — headers passed to it still end with `:` so its regexes match.
+- The Elif branch also works for inline `elif b: two()` because `node.body` was filled before attachment.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx jest __tests__/parser-python-accuracy.test.ts __tests__/parser.test.ts`
+Expected: all PASS (the existing if/elif/else and try tests exercise the rewritten attach logic).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/parser/python.ts __tests__/parser-python-accuracy.test.ts
+git commit -m "fix(parser): parse Python inline suites and fix else/elif attachment"
+```
+
+---
+
+### Task 3: `try/else` rendering + raise routes to except (fixes 8 render + 5 Python half)
+
+**Files:**
+- Modify: `lib/parser/python.ts` (`processTry` ~line 224, `processRaise` ~line 295, `processFunction` ~line 149)
+- Test: `__tests__/parser-python-accuracy.test.ts`
+
+**Interfaces:**
+- Consumes: `TraversalContext.throwTarget` (Part 1 Task 5) and `Try.elsebody` (Task 2).
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+describe('fix 8 (render): try/except/else', () => {
+  test('else block runs after try body succeeds', () => {
+    const code = 'try:\n    risky()\nexcept ValueError:\n    handle()\nelse:\n    celebrate()\nprint("done")'
+    const out = codeToMermaid(code, 'python')
+    const riskyId = out.match(/(N\d+)\["risky\(\)"\]/)?.[1]
+    const celebId = out.match(/(N\d+)\["celebrate\(\)"\]/)?.[1]
+    expect(celebId).toBeTruthy()
+    expect(out).toContain(`${riskyId} --> ${celebId}`)
+  })
+})
+
+describe('fix 5 (python): raise routes to except', () => {
+  test('raise inside try connects to the first except node', () => {
+    const code = 'try:\n    if bad:\n        raise ValueError("x")\n    ok()\nexcept ValueError:\n    handle()'
+    const out = codeToMermaid(code, 'python')
+    const raiseId = out.match(/(N\d+)\["raise ValueError\('x'\)"\]/)?.[1]
+    const exceptId = out.match(/(N\d+)\(\["except ValueError"\]\)/)?.[1]
+    expect(raiseId).toBeTruthy()
+    expect(exceptId).toBeTruthy()
+    expect(out).toContain(`${raiseId} --> ${exceptId}`)
+  })
+
+  test('raise with no enclosing try stays terminal', () => {
+    const out = codeToMermaid('raise RuntimeError("boom")', 'python')
+    const raiseId = out.match(/(N\d+)\["raise RuntimeError\('boom'\)"\]/)?.[1]
+    expect(out).not.toMatch(new RegExp(`${raiseId} --> `))
+  })
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx jest __tests__/parser-python-accuracy.test.ts -t "fix 8 (render)"` and `-t "fix 5 (python)"`
+Expected: FAIL — `celebrate()` absent; raise node has no outgoing edge.
+
+- [ ] **Step 3: Implement**
+
+Replace `processTry` in `lib/parser/python.ts` — handler nodes are created **before** the try body so raises can route to them; `elsebody` renders on the success path:
+
+```ts
+function processTry(node: PyNode, ctx: TraversalContext): BlockResult {
+  const tryNode = ctx.graph.createNode('process', 'try', 'rounded')
+  const after   = ctx.graph.createNode('merge' as any, '', 'circle')
+
+  const handlerNodes: FlowchartNode[] = []
+  for (const h of (node.handlers ?? [])) {
+    const label = h.exceptionType ? (h.name ? `except ${h.exceptionType} as ${h.name}` : `except ${h.exceptionType}`) : 'except'
+    const catchN = ctx.graph.createNode('process', label, 'rounded')
+    ctx.graph.connect(tryNode, catchN, 'error')
+    handlerNodes.push(catchN)
+  }
+  const finallyNode: FlowchartNode | null = node.finalbody?.body
+    ? ctx.graph.createNode('process', 'finally', 'rounded')
+    : null
+
+  const tCtx = ctx.clone(); tCtx.currentNode = tryNode
+  tCtx.throwTarget = handlerNodes[0] ?? finallyNode
+  const tRes = processBlock(node.body ?? [], tCtx)
+  if (tRes.entry) ctx.graph.connect(tryNode, tRes.entry)
+
+  if (finallyNode) {
+    const fCtx = ctx.clone(); fCtx.currentNode = finallyNode
+    const fRes = processBlock(node.finalbody!.body, fCtx)
+    if (fRes.entry) ctx.graph.connect(finallyNode, fRes.entry)
+    ctx.graph.connect(fRes.exit ?? finallyNode, after)
+  }
+
+  const target = finallyNode ?? after
+
+  // try/else runs only when the try body completed without raising
+  let successExit = tRes.exit
+  if (node.elsebody && successExit) {
+    const eCtx = ctx.clone(); eCtx.currentNode = null
+    const eRes = processBlock(node.elsebody.body ?? [], eCtx)
+    if (eRes.entry) { ctx.graph.connect(successExit, eRes.entry); successExit = eRes.exit }
+  }
+  if (successExit) ctx.graph.connect(successExit, target)
+
+  for (let i = 0; i < handlerNodes.length; i++) {
+    const h = (node.handlers ?? [])[i]
+    const cCtx = ctx.clone(); cCtx.currentNode = handlerNodes[i]
+    const cRes = processBlock(h.body ?? [], cCtx)
+    if (cRes.entry) ctx.graph.connect(handlerNodes[i], cRes.entry)
+    ctx.graph.connect(cRes.exit ?? handlerNodes[i], target)
+  }
+
+  return { entry: tryNode, exit: after }
+}
+```
+
+Replace `processRaise`:
+
+```ts
+function processRaise(node: PyNode, ctx: TraversalContext): BlockResult {
+  const n = ctx.graph.createNode('process', node.exception ? `raise ${node.exception}` : 'raise', 'rectangle')
+  if (ctx.throwTarget) ctx.graph.connect(n, ctx.throwTarget)
+  return { entry: n, exit: null }
+}
+```
+
+In `processFunction`, after `fCtx.returnTarget = end` add function-boundary resets (matching Part 1):
+
+```ts
+fCtx.breakTarget = null; fCtx.continueTarget = null; fCtx.throwTarget = null
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx jest __tests__/parser-python-accuracy.test.ts __tests__/parser.test.ts`
+Expected: all PASS (existing try/except/finally test asserts labels only).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/parser/python.ts __tests__/parser-python-accuracy.test.ts
+git commit -m "fix(parser): render Python try/else and route raise to except"
+```
+
+---
+
+### Task 4: `while ... else` renders (fix 9)
+
+**Files:**
+- Modify: `lib/parser/python.ts` (`processWhile` ~line 214)
+- Test: `__tests__/parser-python-accuracy.test.ts`
+
+**Interfaces:** none new (`While.orelse` already attached by `parsePython`).
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+describe('fix 9: while-else', () => {
+  test('else body renders on the No path', () => {
+    const code = 'while cond():\n    work()\nelse:\n    cleanup()\nprint("done")'
+    const out = codeToMermaid(code, 'python')
+    const condId = out.match(/(N\d+)\{"cond\(\)\?"\}/)?.[1]
+    const cleanId = out.match(/(N\d+)\["cleanup\(\)"\]/)?.[1]
+    expect(cleanId).toBeTruthy()
+    expect(out).toContain(`${condId} -->|No| ${cleanId}`)
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx jest __tests__/parser-python-accuracy.test.ts -t "fix 9"`
+Expected: FAIL — `cleanup()` absent.
+
+- [ ] **Step 3: Implement**
+
+In `processWhile`, replace the unconditional `ctx.graph.connect(cond, after, 'No')` with the same `orelse` handling `processFor` already has:
+
+```ts
+if (node.orelse?.body?.length) {
+  const eCtx = ctx.clone(); eCtx.currentNode = null
+  const eRes = processBlock(node.orelse.body, eCtx)
+  if (eRes.entry) { ctx.graph.connect(cond, eRes.entry, 'No'); if (eRes.exit) ctx.graph.connect(eRes.exit, after) }
+  else ctx.graph.connect(cond, after, 'No')
+} else ctx.graph.connect(cond, after, 'No')
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx jest __tests__/parser-python-accuracy.test.ts __tests__/parser.test.ts`
+Expected: all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/parser/python.ts __tests__/parser-python-accuracy.test.ts
+git commit -m "fix(parser): render Python while-else body"
+```
+
+---
+
+### Task 5: `async def` / `async for` / `async with` + def return annotations (fix 10)
+
+**Files:**
+- Modify: `lib/parser/python.ts` (`parseLine` ~line 14, `processFunction`, `processWith`)
+- Test: `__tests__/parser-python-accuracy.test.ts`
+
+**Interfaces:** `PyNode` gains optional `isAsync?: boolean`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+describe('fix 10: async constructs', () => {
+  test('async def renders its body with async label', () => {
+    const code = 'async def fetch(url):\n    if not url:\n        return None\n    return await get(url)'
+    const out = codeToMermaid(code, 'python')
+    expect(out).toContain('async def fetch(url)')
+    expect(out).toContain('not url?')
+  })
+
+  test('async with and async for parse as blocks', () => {
+    const code = 'async def main():\n    async with session() as s:\n        async for item in s.stream():\n            handle(item)'
+    const out = codeToMermaid(code, 'python')
+    expect(out).toContain('async with session() as s')
+    expect(out).toContain('item in s.stream()?')
+    expect(out).toContain('handle(item)')
+  })
+
+  test('def with return annotation parses', () => {
+    const code = 'def size(x) -> int:\n    return len(x)'
+    const out = codeToMermaid(code, 'python')
+    expect(out).toContain('def size(x)')
+    expect(out).toContain('return len(x)')
+  })
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx jest __tests__/parser-python-accuracy.test.ts -t "fix 10"`
+Expected: FAIL — async lines and annotated defs fall through to plain `Expr` boxes; bodies flatten.
+
+- [ ] **Step 3: Implement**
+
+In `parseLine`, add as the **first** check (before the `def` regex):
+
+```ts
+if (line.startsWith('async ')) {
+  const node = parseLine(line.slice(6).trim(), lineNum)
+  if (node && (node.type === 'FunctionDef' || node.type === 'For' || node.type === 'With')) node.isAsync = true
+  return node
+}
+```
+
+Change the `def` regex to tolerate a return annotation:
+
+```ts
+if ((m = line.match(/^def\s+(\w+)\s*\((.*?)\)\s*(?:->\s*[^:]+)?:/)))
+```
+
+In `processFunction`, change the label line to:
+
+```ts
+const fn = ctx.graph.createNode('subroutine', `${node.isAsync ? 'async ' : ''}def ${node.name}(${node.params})`, 'rounded')
+```
+
+In `processWith`, change the label line to:
+
+```ts
+const w = ctx.graph.createNode('process', `${node.isAsync ? 'async ' : ''}with ${node.items}`, 'rounded')
+```
+
+(`async for` needs no label change — the loop diamond `item in s.stream()?` already reads naturally; the fix is that the body now parses. This is a deliberate refinement of the spec's "prepend async" wording for `for`.)
+
+- [ ] **Step 4: Run the full suite**
+
+Run: `npx jest`
+Expected: all suites PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/parser/python.ts __tests__/parser-python-accuracy.test.ts
+git commit -m "fix(parser): support Python async constructs and def return annotations"
+```

--- a/docs/superpowers/specs/2026-07-10-parser-accuracy-design.md
+++ b/docs/superpowers/specs/2026-07-10-parser-accuracy-design.md
@@ -1,0 +1,63 @@
+# Parser Accuracy Fixes — Design
+
+**Date:** 2026-07-10
+**Scope:** `lib/parser/` (javascript.ts, python.ts, types.ts). No UI, API, or converter changes expected (converter.ts only if a fix needs a new edge label).
+**Goal:** Fix 10 confirmed conversion-accuracy defects found by empirical audit, keeping the existing architecture: language parser → `FlowchartGraph` → Mermaid.
+
+## Confirmed defects
+
+| # | Lang | Defect |
+|---|------|--------|
+| 1 | JS/TS | Arrow-function / function-expression bodies render as one opaque box |
+| 2 | JS/TS | Classes render as a single node labeled "ClassDeclaration" |
+| 3 | JS/TS | `switch` without `default` has no "no match" exit edge — flow dead-ends |
+| 4 | JS/TS | Labeled statements render as one node "Labeled"; `break label` targets wrong loop |
+| 5 | JS/TS + Py | `throw`/`raise` inside `try` doesn't route to the handler (dead-end node) |
+| 6 | Py | Single-line suites (`if x: f()`) silently drop the body |
+| 7 | Py | Statements continued across physical lines shatter into one box per line |
+| 8 | Py | `try/except/else` — the `else` block vanishes |
+| 9 | Py | `while ... else` — the `else` body vanishes (`for ... else` already works) |
+| 10 | Py | `async def` / `async for` / `async with` not recognized; bodies flatten |
+
+## Design per fix
+
+### JavaScript / TypeScript (`javascript.ts`)
+
+**1. Function-valued expressions.** Extract a shared helper `processFunctionBody(label, bodyStatements, ctx)` from `processFunction` (creates subroutine + end node, sets `returnTarget`, walks body). Use it from:
+- `FunctionDeclaration` (as today),
+- `VariableDeclaration` declarators whose init is `ArrowFunctionExpression`/`FunctionExpression` with a **block body** — label `const add = (a, b) =>` / `function name(a, b)`; declarators are processed individually so mixed declarations still work,
+- `ExpressionStatement` assignments whose RHS is such a function (`obj.fn = function () {…}`).
+
+Expression-bodied arrows (`x => x * 2`) stay a single process node — no internal control flow to draw.
+
+**2. Classes.** Mirror Python's `processClass`: `ClassDeclaration`/`ClassExpression` renders a subroutine node `class Name` (with ` extends Base` when present), then each `MethodDefinition` body via `processFunctionBody` with label `name(params)` (`constructor(...)`, `get x()`, `static f()` prefixes preserved). Class fields render as one process node each; fields with function values go through fix 1's path.
+
+**3. Switch no-match edge.** In `processSwitch`, track whether a `default` case exists. If not, connect the switch decision → `after` merge with label `no match`.
+
+**4. Labeled statements.** Add `labeledTargets: Record<string, { break: FlowchartNode | null; continue: FlowchartNode | null }>` to `TraversalContext` (copied by spread in `clone()`), plus a transient `pendingLabel: string | null`. `LabeledStatement` sets `pendingLabel = label` and processes its body. Each loop processor (and `processSwitch`) registers its targets under `pendingLabel` (then clears it) before walking the body. `processBreak`/`processContinue` with a label resolve via `labeledTargets`, falling back to the unlabeled target.
+
+**5. Throw routing.** Add `throwTarget: FlowchartNode | null` to `TraversalContext`. `processTry` creates the catch node **before** walking the try body and sets `throwTarget` to it (or to the `finally` node when there is no handler) for the try-body context only. `processThrow` connects to `throwTarget` when set; with no enclosing try it stays a terminal node (uncaught throw = flow stops), unchanged from today. Python `processRaise` gets the identical treatment with `throwTarget` = first `except` handler node.
+
+### Python (`python.ts`)
+
+**7. Logical-line joining (done first — fixes 6 depends on its scanner).** New preprocessing step in `parsePython`: merge physical lines into logical lines before parsing. A small character scanner tracks bracket depth (`()[]{}`), string state (single/double quotes with escape handling, and triple-quoted strings), and trailing-backslash continuation. Lines are joined with a single space; indentation comes from the first physical line. `#` comments are stripped only when outside a string.
+
+**6. Single-line suites.** Compound headers (`if/elif/else/for/while/def/try/except/finally/with/class/match/case`) currently require the line to end with `:`. Using the same scanner, find the **top-level** colon that terminates the header. If non-comment text follows it (`if x > 0: print("hi")`), split the remainder on top-level `;`, parse each piece via `parseLine`, and attach them as the node's `body` (no stack push — the suite is complete inline).
+
+**8. try/except/else + misattachment.** Replace the "reverse-find an If/For/While" attachment logic for `Elif`/`Else` with: look at the **last** statement of the parent body and attach based on its type — `If` → `_elseNode` (via `getLastIf` tail), `For`/`While` → `orelse`, `Try` → new `elsebody` field. This both supports `try/else` and prevents an `else` from ever attaching to an earlier, unrelated `if`. Rendering: in `processTry`, the else block runs after the try body succeeds — `tryBody.exit → elseBlock → (finally ?? after)`; the handlers still connect straight to `(finally ?? after)`.
+
+**9. while-else.** `processWhile` handles `node.orelse` exactly as `processFor` already does: `cond —No→ elseBody → after`.
+
+**10. async.** In `parseLine`, if the trimmed line starts with `async `, strip the prefix, parse the remainder normally, and prepend `async ` to the rendered label for `def`/`for`/`with`.
+
+## Error handling
+
+No change to the public contract: `codeToMermaid(code, language)` still throws `Error` with a line number on unparseable JS/TS and never throws for Python (best-effort line parsing). The Python scanner must be total — unclosed brackets/strings at EOF flush the pending logical line as-is rather than erroring.
+
+## Testing
+
+Extend `__tests__/parser.test.ts` with one focused test per defect (10+), asserting on graph/Mermaid structure (e.g. "the arrow-function body's `if` produces a decision node", "switch decision has an edge to the merge when no default"). Existing tests must keep passing. Each fix is implemented test-first.
+
+## Out of scope
+
+Decorators, walrus operator, comprehension internals, Python `match` guard patterns, JS generators (`yield` control flow), replacing the Python line parser with a real AST parser, and any layout/rendering changes.

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -14,6 +14,10 @@ const config: Config = {
       screens: { "2xl": "1400px" },
     },
     extend: {
+      fontFamily: {
+        sans: ["var(--font-sans)", "system-ui", "sans-serif"],
+        mono: ["var(--font-mono)", "ui-monospace", "monospace"],
+      },
       colors: {
         border:      "hsl(var(--border))",
         input:       "hsl(var(--input))",


### PR DESCRIPTION
 ## Summary

  The app previously had no visual identity — a monochrome slate theme with no
  brand color, generic typography, and a sparse landing page with a feature grid
  that didn't collapse on mobile. This PR applies a cohesive dark
  "coding-platform" design system across the app.

  ## Changes

  **Design system**
  - Green primary accent (`hsl(142 71% 45%)`) for CTAs, focus rings, and text
    selection on a deeper near-black background
  - Brighter destructive red that meets WCAG contrast on dark surfaces (the old
    value was too dark to read as text)
  - Fira Code added via `next/font` as the mono font for the logo chip, code
    snippets, badges, and timestamps; Inter remains the body font

  **Landing page**
  - Responsive hero (was fixed `text-6xl` at all breakpoints)
  - Language chip, code-window → flowchart illustration, footer
  - Feature grid now collapses to one column on mobile (was fixed `grid-cols-3`)

  **Navbar & auth**
  - Workflow logo mark in navbar and auth pages
  - Auth cards moved onto `bg-card` surface with a green top accent

  **Dashboard**
  - Flowchart count in the header
  - Empty state: dashed-border card with icon badge and proper CTA button

  **Polish & accessibility**
  - FlowchartCard hover lift with `motion-reduce` fallback
  - DottedSurface respects `prefers-reduced-motion` (renders a single static
    frame) and is dimmed so it doesn't compete with text

  ## Testing

  - `tsc --noEmit` and `next build` pass
  - Verified in headless Chromium: landing, login, and dashboard render
    correctly with no console errors